### PR TITLE
Improve release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <a href="https://github.com/tmattio/spin/actions">
-    <img src="https://github.com/tmattio/spin/workflows/CI/CD%20Pipeline/badge.svg" alt="Build Status" />
+    <img src="https://github.com/tmattio/spin/workflows/Continuous%20Integration/badge.svg" alt="Build Status" />
   </a>
   <a href="https://badge.fury.io/js/%40tmattio%2Fspin">
     <img src="https://badge.fury.io/js/%40tmattio%2Fspin.svg" alt="npm version" />

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -34,15 +34,20 @@ release=$1
 
 if [ -d ".git" ]; then
   changes=$(git status --porcelain)
+  branch=$(git rev-parse --abbrev-ref HEAD)
 
-  if [ -z "${changes}" ]; then
+  if [ -n "${changes}" ]; then
+    echo "Please commit staged files prior to bumping"
+    exit 1
+  elif [ "${branch}" != "master" ]; then
+    echo "Please run the release script on master"
+    exit 1
+  else
     bump_all
     git add .
     git commit -m "Bump to ${version}"
     git tag -a "${output}" -m "${version}"
     git push origin --tags
-  else
-    echo "Please commit staged files prior to bumping"
   fi
 else
   bump_all


### PR DESCRIPTION
A first version of the release process has been merged in master, but there are still a couple things missing.

This PR brings the release process to a satisfying step, while preparing the extraction of spin in a `cli` template.

- [ ] Fix Windows build (#17)
- [ ] Fix yarn installation (#18)
- [ ] Brew formula conflicts with an existing one (#19)
- [ ] Add a changelog and integrate in release script
- [ ] Generate demo on release
