### PR TITLE
Fail gracefully when remote repository can't be reached

### DIFF
--- a/lib/errors.re
+++ b/lib/errors.re
@@ -67,7 +67,7 @@ let handle_errors = fn =>
     );
     Caml.exit(207);
   | Cannot_access_remote_repository =>
-      Console.error(
+    Console.error(
       <Pastel color=Pastel.Red>
         "😱  Error while accessing remote repository, please check your Internet connection."
       </Pastel>,

--- a/lib/errors.re
+++ b/lib/errors.re
@@ -5,6 +5,7 @@ exception Config_file_syntax_error;
 exception Current_directory_not_a_spin_project;
 exception Generator_does_not_exist(string);
 exception Cannot_parse_template_file(string);
+exception Cannot_access_remote_repository;
 
 let handle_errors = fn =>
   try(fn()) {
@@ -65,6 +66,13 @@ let handle_errors = fn =>
       </Pastel>,
     );
     Caml.exit(207);
+  | Cannot_access_remote_repository =>
+      Console.error(
+      <Pastel color=Pastel.Red>
+        "😱  Error while accessing remote repository, please check your Internet connection."
+      </Pastel>,
+    );
+    Caml.exit(208);
   | _ as exn =>
     Console.log(
       <Pastel color=Pastel.Red>
@@ -92,4 +100,5 @@ let all = () => [
   },
   {doc: "on calling a generator that does not exist.", exit_code: 206},
   {doc: "on failure to parse a template file.", exit_code: 207},
+  {doc: "on failure to access the remote repository", exit_code: 208},
 ];

--- a/lib/errors.rei
+++ b/lib/errors.rei
@@ -5,6 +5,7 @@ exception Config_file_syntax_error;
 exception Current_directory_not_a_spin_project;
 exception Generator_does_not_exist(string);
 exception Cannot_parse_template_file(string);
+exception Cannot_access_remote_repository;
 
 let handle_errors: (unit => 'a) => 'a;
 

--- a/lib/template_official.re
+++ b/lib/template_official.re
@@ -8,13 +8,13 @@ let url = "https://github.com/tmattio/spin-templates.git";
 let ensure_downloaded = () =>
   if (Utils.Filename.test(Utils.Filename.Is_dir, path)) {
     Console.log(<Pastel> "📡  Updating official templates." </Pastel>);
-    let _ = Lwt_main.run(Vcs.git_pull(path));
+    let _ = Errors.handle_errors(() => Lwt_main.run(Vcs.git_pull(path)));
     Console.log(
       <Pastel color=Pastel.GreenBright bold=true> "Done!\n" </Pastel>,
     );
   } else {
     Console.log(<Pastel> "📡  Downloading official templates." </Pastel>);
-    let _ = Lwt_main.run(Vcs.git_clone(url, ~destination=path, ~branch));
+    let _ = Errors.handle_errors(() => Lwt_main.run(Vcs.git_clone(url, ~destination=path, ~branch)));
     Console.log(
       <Pastel color=Pastel.GreenBright bold=true> "Done!\n" </Pastel>,
     );

--- a/lib/template_official.re
+++ b/lib/template_official.re
@@ -14,7 +14,10 @@ let ensure_downloaded = () =>
     );
   } else {
     Console.log(<Pastel> "📡  Downloading official templates." </Pastel>);
-    let _ = Errors.handle_errors(() => Lwt_main.run(Vcs.git_clone(url, ~destination=path, ~branch)));
+    let _ =
+      Errors.handle_errors(() =>
+        Lwt_main.run(Vcs.git_clone(url, ~destination=path, ~branch))
+      );
     Console.log(
       <Pastel color=Pastel.GreenBright bold=true> "Done!\n" </Pastel>,
     );

--- a/lib/vcs.re
+++ b/lib/vcs.re
@@ -37,9 +37,9 @@ let git_pull = repo => {
     );
   switch (result) {
   | WEXITED(0) =>
-      try(result |> Lwt.return) {
-      | _ => Lwt.fail(Errors.Cannot_access_remote_repository)
-      };
+    try(result |> Lwt.return) {
+    | _ => Lwt.fail(Errors.Cannot_access_remote_repository)
+    }
   | _ => Lwt.fail(Errors.Cannot_access_remote_repository)
-  }
+  };
 };

--- a/lib/vcs.re
+++ b/lib/vcs.re
@@ -35,7 +35,11 @@ let git_pull = repo => {
       ~stdout=Lwt_process.(`Dev_null),
       ~stderr=Lwt_process.(`Dev_null),
     );
-  try(result |> Lwt.return) {
-  | _ => Lwt.fail_with("Error while pulling the repository")
-  };
+  switch (result) {
+  | WEXITED(0) =>
+      try(result |> Lwt.return) {
+      | _ => Lwt.fail(Errors.Cannot_access_remote_repository)
+      };
+  | _ => Lwt.fail(Errors.Cannot_access_remote_repository)
+  }
 };


### PR DESCRIPTION
Closes #34

This PR implements better error handling and user facing messaging in case the remote repository can't be reached.

<img width="675" alt="Screen Shot 2020-02-06 at 23 14 54" src="https://user-images.githubusercontent.com/47985/73957141-d83ca400-48fd-11ea-89e3-96d0cf59aff6.png">
