### PR TITLE
Add extra check for local templates

### DIFF
--- a/bin/commands/cmd_new.re
+++ b/bin/commands/cmd_new.re
@@ -22,7 +22,7 @@ let cmd = {
   let doc = "Create a new ReasonML/Ocaml project from a template";
 
   let template = {
-    let doc = "The template to use to generate the project. Can be the name of an official template or a git repository.";
+    let doc = "The template to use to generate the project. Can be the name of an official template, a git repository or a local template directory.";
     Arg.(
       required
       & pos(0, some(string), None)

--- a/lib/source.re
+++ b/lib/source.re
@@ -25,8 +25,16 @@ let to_local_path: t => local =
       tempdir;
     };
 
+let is_local_template_dir = s => {
+  Utils.Filename.(
+    test(Exists, s)
+    && test(Exists, s ++ "/spin")
+    && test(Exists, s ++ "/template/spin")
+  );
+};
+
 let of_string = (s: string) =>
-  if (Utils.Filename.test(Utils.Filename.Exists, s)) {
+  if (is_local_template_dir(s)) {
     Local_dir(s);
   } else if (Vcs.is_git_url(s)) {
     Git(s);

--- a/lib/source.re
+++ b/lib/source.re
@@ -28,8 +28,8 @@ let to_local_path: t => local =
 let is_local_template_dir = s => {
   Utils.Filename.(
     test(Exists, s)
-    && test(Exists, join([s, "/spin"]))
-    && test(Exists, join([s, "/template/spin"]))
+    && test(Exists, join([s, "spin"]))
+    && test(Exists, join([s, "template", "spin"]))
   );
 };
 

--- a/lib/source.re
+++ b/lib/source.re
@@ -28,8 +28,8 @@ let to_local_path: t => local =
 let is_local_template_dir = s => {
   Utils.Filename.(
     test(Exists, s)
-    && test(Exists, s ++ "/spin")
-    && test(Exists, s ++ "/template/spin")
+    && test(Exists, join([s, "/spin"]))
+    && test(Exists, join([s, "/template/spin"]))
   );
 };
 


### PR DESCRIPTION
Closes #65 

This PR  adds extra checks for local template sources (it checks for the presence of `spin` and `template/spin`). 

Additionally, it updates the help description:

```
TEMPLATE (required)
    The template to use to generate the project. Can be the name of an
    official template, a git repository or a local template directory.
```

@tmattio Wasn't quite sure how this would fit into the current testing strategy, so I didn't add a test (yet). 