### PR TITLE
Output helpful message if postinstall command is missing

### DIFF
--- a/lib/errors.re
+++ b/lib/errors.re
@@ -8,7 +8,6 @@ exception Cannot_parse_template_file(string);
 exception Cannot_access_remote_repository(string);
 exception Generator_files_already_exist(string);
 exception Subprocess_exited_with_non_zero(string, int);
-exception External_command_unavailable(string);
 exception Cannot_checkout_version(string);
 
 let print_err = e => {
@@ -91,14 +90,6 @@ let handle_errors = fn =>
     ]);
 
     Caml.exit(210);
-  | External_command_unavailable(command) =>
-    print_err([
-      "External command not available: ",
-      command,
-      ". Please install it and try again.",
-    ]);
-
-    Caml.exit(211);
   | Cannot_checkout_version(version) =>
     print_err([
       "Spin depends on version ",
@@ -135,7 +126,6 @@ let all = () => [
   {doc: "on failure to access the remote repository", exit_code: 208},
   {doc: "on generating a file that already exist.", exit_code: 209},
   {doc: "on subprocess exit with a non-zero status code.", exit_code: 210},
-  {doc: "on calling a missing external command.", exit_code: 211},
   {
     doc: "on failure to use the correct version of the official templates.",
     exit_code: 212,

--- a/lib/errors.rei
+++ b/lib/errors.rei
@@ -8,7 +8,6 @@ exception Cannot_parse_template_file(string);
 exception Cannot_access_remote_repository(string);
 exception Generator_files_already_exist(string);
 exception Subprocess_exited_with_non_zero(string, int);
-exception External_command_unavailable(string);
 exception Cannot_checkout_version(string);
 
 let handle_errors: (unit => 'a) => 'a;

--- a/lib/template.re
+++ b/lib/template.re
@@ -165,7 +165,7 @@ let generate =
               ".\n",
               "Please run: \"",
               command_string,
-              "\"\n"
+              "\"\n",
             ],
           )
           |> Stdio.print_endline

--- a/test/spin_app/cmd_new_test.re
+++ b/test/spin_app/cmd_new_test.re
@@ -30,8 +30,8 @@ describe("Integration test templates", ({test, _}) => {
         "sample_template_postinstall_unavailable",
       ]);
 
-    let status_new =
-      Test_utils.exec([|"new", "--default", template_dir, working_dir|]);
-    expect.int(status_new).toBe(211);
+    let output =
+      Test_utils.run([|"new", "--default", template_dir, working_dir|]);
+    expect.string(output).toMatch("Please run:");
   })
 });


### PR DESCRIPTION
Closes #67 

This PR changes the behavior of post-install commands to outputting a helpful message instead of failing:

<img width="476" alt="Screen Shot 2020-03-26 at 23 24 58" src="https://user-images.githubusercontent.com/47985/77672095-60473d80-6f80-11ea-8e75-f8039a673850.png">

@tmattio Since this removes error 211, I wondered if you want to move the recently introduced 212 to 211? 