### PR TITLE
Add makefile documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,11 @@ clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc: ## Generate odoc documentation and open it with the default browser
+doc: ## Generate odoc documentation
 	opam exec -- dune build --root . @doc
+
+.PHONY: servedoc
+servedoc: doc ## Open odoc documentation with default web browser
 	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format

--- a/Makefile
+++ b/Makefile
@@ -1,61 +1,86 @@
+.DEFAULT_GOAL := all
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
+
+.PHONY: help
+help: ## Print this help message
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
 
 .PHONY: all
 all:
 	opam exec -- dune build --root . @install
 
 .PHONY: dev
-dev:
+dev: ## Install development dependencies
 	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: build
-build:
+build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .
 
 .PHONY: start
-start: all
+start: all ## Start the project
 	opam exec -- dune exec --root . bin/main.exe $(ARGS)
 
 .PHONY: install
-install:
+install: all ## Install the packages on the system
 	opam exec -- dune install --root .
 
 .PHONY: test
-test:
+test: ## Run the unit tests
 	opam exec -- dune build --root . @test/runtest -f
 	opam exec -- dune build --root . @test_bin/runtest -f
 
 .PHONY: test-template
-test-template:
+test-template: ## Run the template integration tests
 	opam exec -- dune build --root . @test_template/runtest -f -j 1
 
 .PHONY: clean
-clean:
+clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc:
+doc: ## Generate odoc documentation and open it with the default browser
 	opam exec -- dune build --root . @doc
-
-.PHONY: doc-path
-doc-path:
-	@echo "_build/default/_doc/_html/index.html"
+	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format
-format:
+format: ## Format the codebase with ocamlformat
 	opam exec -- dune build --root . @fmt --auto-promote
 
 .PHONY: watch
-watch:
+watch: ## Watch for the filesystem and rebuild on every change
 	opam exec -- dune build ---root . -watch
 
 .PHONY: utop
-utop:
+utop: ## Run a REPL and link with the project's libraries
 	opam exec -- dune utop --root . lib -- -implicit-bindings
 
 .PHONY: release
-release:
+release: ## Run the release script
 	opam exec -- sh script/release.sh

--- a/template/bin/template/Makefile
+++ b/template/bin/template/Makefile
@@ -69,8 +69,11 @@ clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc: ## Generate odoc documentation and open it with the default browser
+doc: ## Generate odoc documentation
 	opam exec -- dune build --root . @doc
+
+.PHONY: servedoc
+servedoc: doc ## Open odoc documentation with default web browser
 	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format

--- a/template/bin/template/Makefile
+++ b/template/bin/template/Makefile
@@ -1,3 +1,34 @@
+.DEFAULT_GOAL := all
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(eval $(ARGS):;@:)
+
+.PHONY: help
+help: ## Print this help message
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
@@ -6,7 +37,7 @@ all:
 	opam exec -- dune build --root . @install
 
 .PHONY: dev
-dev:
+dev: ## Install development dependencies
 	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	{%- if test_framework == 'Rely' %}
@@ -18,41 +49,38 @@ dev:
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: build
-build:
+build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .
 
 .PHONY: install
-install:
+install: all ## Install the packages on the system
 	opam exec -- dune install --root .
 
 .PHONY: start
-start: all
+start: all ## Run the produced executable
 	opam exec -- dune exec --root . bin/main.exe $(ARGS)
 
 .PHONY: test
-test:
-	opam exec -- {% if test_framework == 'Rely' %}dune exec test/test_runner.exe{% else %}dune build @test/runtest -f{% endif %}
+test: ## Run the unit tests
+	opam exec -- {% if test_framework == 'Rely' %}dune exec --root . test/test_runner.exe{% else %}dune build --root . @test/runtest -f{% endif %}
 
 .PHONY: clean
-clean:
+clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc:
+doc: ## Generate odoc documentation and open it with the default browser
 	opam exec -- dune build --root . @doc
-
-.PHONY: doc-path
-doc-path:
-	@echo "_build/default/_doc/_html/index.html"
+	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format
-format:
+format: ## Format the codebase with ocamlformat
 	opam exec -- dune build --root . --auto-promote @fmt
 
 .PHONY: watch
-watch:
+watch: ## Watch for the filesystem and rebuild on every change
 	opam exec -- dune build --root . --watch
 
 .PHONY: utop
-utop:
+utop: ## Run a REPL and link with the project's libraries
 	opam exec -- dune utop --root . lib -- -implicit-bindings

--- a/template/cli/template/Makefile
+++ b/template/cli/template/Makefile
@@ -69,8 +69,11 @@ clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc: ## Generate odoc documentation and open it with the default browser
+doc: ## Generate odoc documentation
 	opam exec -- dune build --root . @doc
+
+.PHONY: servedoc
+servedoc: doc ## Open odoc documentation with default web browser
 	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format

--- a/template/cli/template/Makefile
+++ b/template/cli/template/Makefile
@@ -1,3 +1,34 @@
+.DEFAULT_GOAL := all
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(eval $(ARGS):;@:)
+
+.PHONY: help
+help: ## Print this help message
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
@@ -6,7 +37,7 @@ all:
 	opam exec -- dune build --root . @install
 
 .PHONY: dev
-dev:
+dev: ## Install development dependencies
 	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	{%- if test_framework == 'Rely' %}
@@ -18,45 +49,42 @@ dev:
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: build
-build:
+build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .
 
-.PHONY: start
-start: all
-	opam exec -- dune exec bin/main.exe $(ARGS)
-
 .PHONY: install
-install:
+install: all ## Install the packages on the system
 	opam exec -- dune install --root .
 
+.PHONY: start
+start: all ## Run the produced executable
+	opam exec -- dune exec --root . bin/main.exe $(ARGS)
+
 .PHONY: test
-test:
+test: ## Run the unit tests
 	opam exec -- {% if test_framework == 'Rely' %}dune exec --root . test/test_runner.exe{% else %}dune build --root . @test/runtest -f{% endif %}
 
 .PHONY: clean
-clean:
+clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc:
+doc: ## Generate odoc documentation and open it with the default browser
 	opam exec -- dune build --root . @doc
-
-.PHONY: doc-path
-doc-path:
-	@echo "_build/default/_doc/_html/index.html"
+	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format
-format:
+format: ## Format the codebase with ocamlformat
 	opam exec -- dune build --root . --auto-promote @fmt
 
 .PHONY: watch
-watch:
+watch: ## Watch for the filesystem and rebuild on every change
 	opam exec -- dune build --root . --watch
 
 .PHONY: utop
-utop:
+utop: ## Run a REPL and link with the project's libraries
 	opam exec -- dune utop --root . lib -- -implicit-bindings
 
 .PHONY: release
-release:
+release: all ## Run the release script 
 	opam exec -- sh script/release.sh

--- a/template/spa/template/Makefile
+++ b/template/spa/template/Makefile
@@ -64,8 +64,11 @@ clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc: ## Generate odoc documentation and open it with the default browser
+doc: ## Generate odoc documentation
 	opam exec -- dune build --root . @doc
+
+.PHONY: servedoc
+servedoc: doc ## Open odoc documentation with default web browser
 	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format

--- a/template/spa/template/Makefile
+++ b/template/spa/template/Makefile
@@ -1,3 +1,34 @@
+.DEFAULT_GOAL := all
+
+define BROWSER_PYSCRIPT
+import os, webbrowser, sys
+
+from urllib.request import pathname2url
+
+webbrowser.open("file://" + pathname2url(os.path.abspath(sys.argv[1])))
+endef
+export BROWSER_PYSCRIPT
+
+define PRINT_HELP_PYSCRIPT
+import re, sys
+
+for line in sys.stdin:
+	match = re.match(r'^([a-zA-Z_-]+):.*?## (.*)$$', line)
+	if match:
+		target, help = match.groups()
+		print("%-20s %s" % (target, help))
+endef
+export PRINT_HELP_PYSCRIPT
+
+BROWSER := python -c "$$BROWSER_PYSCRIPT"
+
+ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+$(eval $(ARGS):;@:)
+
+.PHONY: help
+help: ## Print this help message
+	@python -c "$$PRINT_HELP_PYSCRIPT" < $(MAKEFILE_LIST)
+
 ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(ARGS):;@:)
 
@@ -6,48 +37,45 @@ all:
 	opam exec -- dune build --root . @install
 
 .PHONY: dev
-dev:
+dev: ## Install development dependencies
 	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	cd asset && npm install
 	opam install --deps-only --with-test --with-doc -y .
 
 .PHONY: build
-build:
+build: ## Build the project, including non installable libraries and executables
 	opam exec -- dune build --root .
 
 .PHONY: install
-install:
+install: all ## Install the packages on the system
 	opam exec -- dune install --root .
 
 .PHONY: start
-start: build
+start: all ## Serve the application with a local HTTP server
 	cd asset && npm start
 
 .PHONY: test
-test:
+test: ## Run the unit tests
 	opam exec -- dune build --root . @test/runtest -f
 
 .PHONY: clean
-clean:
+clean: ## Clean build artifacts and other generated files
 	opam exec -- dune clean --root .
 
 .PHONY: doc
-doc:
+doc: ## Generate odoc documentation and open it with the default browser
 	opam exec -- dune build --root . @doc
-
-.PHONY: doc-path
-doc-path:
-	@echo "_build/default/_doc/_html/index.html"
+	$(BROWSER) _build/default/_doc/_html/index.html
 
 .PHONY: format
-format:
-	opam exec -- dune build --root . @fmt --auto-promote
+format: ## Format the codebase with ocamlformat
+	opam exec -- dune build --root . --auto-promote @fmt
 
 .PHONY: watch
-watch:
+watch: ## Watch for the filesystem and rebuild on every change
 	opam exec -- dune build --root . --watch
 
 .PHONY: utop
-utop:
+utop: ## Run a REPL and link with the project's libraries
 	opam exec -- dune utop --root . lib -- -implicit-bindings


### PR DESCRIPTION
This PR improves the template makefiles with two changes:

- It adds a `help` command that will print an usage documentation of the Makefile
- It automatically opens the default web browser when running `make servedocs`. To do this, it uses an inlined Python script, so the `servedoc` command requires Python to be installed.