### PR TITLE
Create switch by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
 
 ## Fixes
 
-- The project generation will now not fail before the configurations prompt if the output directory is not empty
+- The project generation will now fail before the configurations prompt if the output directory is not empty
+- By default, Spin now creates a local switch for the generated projects. This can be changed with `spin config`, or by setting the env variable `SPIN_CREATE_SWITCH=false`
 
 # 0.7.0
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ You need Opam, you can install it by following [Opam's documentation](https://op
 With Opam installed, you can install the dependencies with:
 
 ```bash
-make dev
+make deps
 ```
 
 Then, build the project with:

--- a/lib/spin/decoders/dec_template.ml
+++ b/lib/spin/decoders/dec_template.ml
@@ -98,6 +98,8 @@ module Expr = struct
 
   and func =
     | If of t * t * t
+    | And of t * t
+    | Or of t * t
     | Eq of t * t
     | Neq of t * t
     | Not of t
@@ -121,6 +123,10 @@ module Expr = struct
       Ok (String s)
     | Sexp.List (Sexp.Atom ("if" as name) :: args) as sexp ->
       decode_fn3 name args ~sexp ~ctor:(fun a b c -> If (a, b, c))
+    | Sexp.List (Sexp.Atom ("and" as name) :: args) as sexp ->
+      decode_fn2 name args ~sexp ~ctor:(fun a b -> And (a, b))
+    | Sexp.List (Sexp.Atom ("or" as name) :: args) as sexp ->
+      decode_fn2 name args ~sexp ~ctor:(fun a b -> Or (a, b))
     | Sexp.List (Sexp.Atom ("eq" as name) :: args) as sexp ->
       decode_fn2 name args ~sexp ~ctor:(fun a b -> Eq (a, b))
     | Sexp.List (Sexp.Atom ("neq" as name) :: args) as sexp ->

--- a/lib/spin/decoders/dec_user_config.ml
+++ b/lib/spin/decoders/dec_user_config.ml
@@ -3,6 +3,7 @@ type t =
   ; email : string option
   ; github_username : string option
   ; npm_username : string option
+  ; create_switch : bool option
   }
 
 let decode =
@@ -10,14 +11,17 @@ let decode =
   let+ username = Decoder.field_opt "username" ~f:Decoder.string
   and+ email = Decoder.field_opt "email" ~f:Decoder.string
   and+ github_username = Decoder.field_opt "github_username" ~f:Decoder.string
-  and+ npm_username = Decoder.field_opt "npm_username" ~f:Decoder.string in
-  { username; email; github_username; npm_username }
+  and+ npm_username = Decoder.field_opt "npm_username" ~f:Decoder.string
+  and+ create_switch = Decoder.field_opt "create_switch" ~f:Decoder.bool in
+  { username; email; github_username; npm_username; create_switch }
 
 let encode t =
   let nullable_string = Encoder.nullable Encoder.string in
+  let nullable_bool = Encoder.nullable Encoder.bool in
   Encoder.obj
     [ "username", nullable_string t.username
     ; "email", nullable_string t.email
     ; "github_username", nullable_string t.github_username
     ; "npm_username", nullable_string t.github_username
+    ; "create_switch", nullable_bool t.create_switch
     ]

--- a/lib/spin/template_expr.ml
+++ b/lib/spin/template_expr.ml
@@ -24,6 +24,14 @@ and eval_fn ~context =
   | Expr.If (e1, e2, e3) ->
     let* e1 = to_bool e1 in
     if e1 then eval e2 else eval e3
+  | Expr.And (e1, e2) ->
+    let* e1 = to_bool e1 in
+    let+ e2 = to_bool e2 in
+    (e1 && e2) |> Bool.to_string
+  | Expr.Or (e1, e2) ->
+    let* e1 = to_bool e1 in
+    let+ e2 = to_bool e2 in
+    (e1 || e2) |> Bool.to_string
   | Expr.Eq (e1, e2) ->
     let* e1 = eval e1 in
     let+ e2 = eval e2 in

--- a/lib/spin/user_config.ml
+++ b/lib/spin/user_config.ml
@@ -3,6 +3,7 @@ type t =
   ; email : string option
   ; github_username : string option
   ; npm_username : string option
+  ; create_switch : bool option
   }
 
 let of_dec (dec : Dec_user_config.t) =
@@ -10,6 +11,7 @@ let of_dec (dec : Dec_user_config.t) =
   ; email = dec.email
   ; github_username = dec.github_username
   ; npm_username = dec.npm_username
+  ; create_switch = dec.create_switch
   }
 
 let path_of_opt value =
@@ -41,6 +43,7 @@ let save ?path t =
     ; email = t.email
     ; github_username = t.github_username
     ; npm_username = t.npm_username
+    ; create_switch = t.create_switch
     }
     ~path
     ~f:Dec_user_config.encode
@@ -72,16 +75,22 @@ let prompt ?default:d () =
       ?default:(Option.bind d ~f:(fun d -> d.github_username))
       ~validate:validate_strip
   in
-  let+ npm_username =
+  let* npm_username =
     Inquire.input
       "Your NPM username"
       ?default:(Option.bind d ~f:(fun d -> d.npm_username))
       ~validate:validate_strip
   in
+  let+ create_switch =
+    Inquire.confirm
+      "Create switches when generating projects"
+      ?default:(Option.bind d ~f:(fun d -> d.create_switch))
+  in
   { username = Some username
   ; email = Some email
   ; github_username = Some github_username
   ; npm_username = Some npm_username
+  ; create_switch = Some create_switch
   }
 
 let to_context t =

--- a/lib/spin/user_config.mli
+++ b/lib/spin/user_config.mli
@@ -3,6 +3,7 @@ type t =
   ; email : string option
   ; github_username : string option
   ; npm_username : string option
+  ; create_switch : bool option
   }
 
 val of_dec : Dec_user_config.t -> t

--- a/template/bin/spin
+++ b/template/bin/spin
@@ -54,7 +54,7 @@
 
 (config ci_cd
   (select
-    (prompt "Which CI/CD do you use")
+    (prompt "Which CI/CD do you use?")
     (values Github None))
   (default Github))
 
@@ -95,14 +95,14 @@
   (actions 
     (run make switch)
     (run make build))
-  (message "🎁  Installing packages. This might take a couple minutes.")
+  (message "🎁  Installing packages in a switch. This might take a couple minutes.")
   (enabled_if (and (eq :package_manager Opam) (eq :create_switch true))))
 
 (post_gen
   (actions 
     (run make deps)
     (run make build))
-  (message "🎁  Installing packages. This might take a couple minutes.")
+  (message "🎁  Installing packages globally. This might take a couple minutes.")
   (enabled_if (and (eq :package_manager Opam) (eq :create_switch false))))
 
 (post_gen

--- a/template/bin/spin
+++ b/template/bin/spin
@@ -14,6 +14,9 @@
 (config project_snake
   (default (snake_case :project_slug)))
 
+(config create_switch
+  (default true))
+
 (config project_description
   (input (prompt "Description"))
   (default "A short, but powerful statement about your project")
@@ -90,10 +93,17 @@
 
 (post_gen
   (actions 
-    (run make dev)
+    (run make switch)
     (run make build))
   (message "🎁  Installing packages. This might take a couple minutes.")
-  (enabled_if (eq :package_manager Opam)))
+  (enabled_if (and (eq :package_manager Opam) (eq :create_switch true))))
+
+(post_gen
+  (actions 
+    (run make deps)
+    (run make build))
+  (message "🎁  Installing packages. This might take a couple minutes.")
+  (enabled_if (and (eq :package_manager Opam) (eq :create_switch false))))
 
 (post_gen
   (actions
@@ -109,7 +119,7 @@
 
 (example_commands
   (commands
-    ("make dev" "Download runtime and development dependencies.")
+    ("make deps" "Download runtime and development dependencies.")
     ("make build" "Build the dependencies and the project.")
     ("make test" "Starts the test runner."))
   (enabled_if (eq :package_manager Opam)))

--- a/template/bin/template/CONTRIBUTING.md
+++ b/template/bin/template/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You need Opam, you can install it by following [Opam's documentation](https://op
 With Opam installed, you can install the dependencies with:
 
 ```bash
-make dev
+make deps
 ```
 
 Then, build the project with:

--- a/template/bin/template/CONTRIBUTING.md
+++ b/template/bin/template/CONTRIBUTING.md
@@ -21,7 +21,13 @@ This project uses [Dune](https://dune.build/) as a build system, if you add a de
 {%- else -%}
 You need Opam, you can install it by following [Opam's documentation](https://opam.ocaml.org/doc/Install.html).
 
-With Opam installed, you can install the dependencies with:
+With Opam installed, you can install the dependencies in a new local switch with:
+
+```bash
+make switch
+```
+
+Or globally, with:
 
 ```bash
 make deps

--- a/template/bin/template/Makefile
+++ b/template/bin/template/Makefile
@@ -36,9 +36,8 @@ $(eval $(ARGS):;@:)
 all:
 	opam exec -- dune build --root . @install
 
-.PHONY: dev
-dev: ## Install development dependencies
-	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
+.PHONY: deps
+deps: ## Install development dependencies
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	{%- if test_framework == 'Rely' %}
 	opam pin add -y pastel https://github.com/facebookexperimental/reason-native.git
@@ -47,6 +46,13 @@ dev: ## Install development dependencies
 	opam pin add -y rely https://github.com/facebookexperimental/reason-native.git
 	{%- endif %}
 	opam install --deps-only --with-test --with-doc -y .
+
+.PHONY: create_switch
+create_switch:
+	opam switch create . --no-install
+
+.PHONY: switch
+switch: create_switch deps ## Create an opam switch and install development dependencies
 
 .PHONY: build
 build: ## Build the project, including non installable libraries and executables

--- a/template/cli/template/CONTRIBUTING.md
+++ b/template/cli/template/CONTRIBUTING.md
@@ -23,6 +23,14 @@ You need Opam, you can install it by following [Opam's documentation](https://op
 
 With Opam installed, you can install the dependencies with:
 
+With Opam installed, you can install the dependencies in a new local switch with:
+
+```bash
+make switch
+```
+
+Or globally, with:
+
 ```bash
 make deps
 ```

--- a/template/cli/template/CONTRIBUTING.md
+++ b/template/cli/template/CONTRIBUTING.md
@@ -24,7 +24,7 @@ You need Opam, you can install it by following [Opam's documentation](https://op
 With Opam installed, you can install the dependencies with:
 
 ```bash
-make dev
+make deps
 ```
 
 Then, build the project with:

--- a/template/cli/template/Makefile
+++ b/template/cli/template/Makefile
@@ -36,9 +36,8 @@ $(eval $(ARGS):;@:)
 all:
 	opam exec -- dune build --root . @install
 
-.PHONY: dev
-dev: ## Install development dependencies
-	opam pin add -y ocaml-lsp-server https://github.com/ocaml/ocaml-lsp.git
+.PHONY: deps
+deps: ## Install development dependencies
 	opam install -y dune-release merlin ocamlformat utop ocaml-lsp-server
 	{%- if test_framework == 'Rely' %}
 	opam pin add -y pastel https://github.com/facebookexperimental/reason-native.git
@@ -47,6 +46,13 @@ dev: ## Install development dependencies
 	opam pin add -y rely https://github.com/facebookexperimental/reason-native.git
 	{%- endif %}
 	opam install --deps-only --with-test --with-doc -y .
+
+.PHONY: create_switch
+create_switch:
+	opam switch create . --no-install
+
+.PHONY: switch
+switch: create_switch deps ## Create an opam switch and install development dependencies
 
 .PHONY: build
 build: ## Build the project, including non installable libraries and executables

--- a/test/spin/decoders/dec_user_config_test.ml
+++ b/test/spin/decoders/dec_user_config_test.ml
@@ -9,6 +9,7 @@ let test_encode_config () =
       ; email = Some "bill@email.com"
       ; github_username = Some "bill"
       ; npm_username = Some "bill"
+      ; create_switch = Some false
       }
   in
   let f = Dec_user_config.encode in
@@ -17,7 +18,8 @@ let test_encode_config () =
     "(username Bill)\n\n\
      (email bill@email.com)\n\n\
      (github_username bill)\n\n\
-     (npm_username bill)"
+     (npm_username bill)\n\n\
+     (create_switch false)"
   in
   check string "same value" expected encoded
 

--- a/test_template/bin/ocaml-esy-alcotest.t
+++ b/test_template/bin/ocaml-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/ocaml-esy-alcotest.t
+++ b/test_template/bin/ocaml-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/ocaml-esy-rely.t
+++ b/test_template/bin/ocaml-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/ocaml-esy-rely.t
+++ b/test_template/bin/ocaml-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/ocaml-opam-alcotest.t
+++ b/test_template/bin/ocaml-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/ocaml-opam-alcotest.t
+++ b/test_template/bin/ocaml-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/ocaml-opam-rely.t
+++ b/test_template/bin/ocaml-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/ocaml-opam-rely.t
+++ b/test_template/bin/ocaml-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/reason-esy-alcotest.t
+++ b/test_template/bin/reason-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/reason-esy-alcotest.t
+++ b/test_template/bin/reason-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/reason-esy-rely.t
+++ b/test_template/bin/reason-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/reason-esy-rely.t
+++ b/test_template/bin/reason-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/reason-opam-alcotest.t
+++ b/test_template/bin/reason-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/reason-opam-alcotest.t
+++ b/test_template/bin/reason-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/bin/reason-opam-rely.t
+++ b/test_template/bin/reason-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/bin/reason-opam-rely.t
+++ b/test_template/bin/reason-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from bin in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/ocaml-esy-alcotest.t
+++ b/test_template/cli/ocaml-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/ocaml-esy-alcotest.t
+++ b/test_template/cli/ocaml-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/ocaml-esy-rely.t
+++ b/test_template/cli/ocaml-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/ocaml-esy-rely.t
+++ b/test_template/cli/ocaml-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/ocaml-opam-alcotest.t
+++ b/test_template/cli/ocaml-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/ocaml-opam-alcotest.t
+++ b/test_template/cli/ocaml-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/ocaml-opam-rely.t
+++ b/test_template/cli/ocaml-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/ocaml-opam-rely.t
+++ b/test_template/cli/ocaml-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/reason-esy-alcotest.t
+++ b/test_template/cli/reason-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/reason-esy-alcotest.t
+++ b/test_template/cli/reason-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/reason-esy-rely.t
+++ b/test_template/cli/reason-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/reason-esy-rely.t
+++ b/test_template/cli/reason-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/reason-opam-alcotest.t
+++ b/test_template/cli/reason-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/reason-opam-alcotest.t
+++ b/test_template/cli/reason-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/cli/reason-opam-rely.t
+++ b/test_template/cli/reason-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/cli/reason-opam-rely.t
+++ b/test_template/cli/reason-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from cli in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/ocaml-esy-alcotest.t
+++ b/test_template/lib/ocaml-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/ocaml-esy-alcotest.t
+++ b/test_template/lib/ocaml-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/ocaml-esy-rely.t
+++ b/test_template/lib/ocaml-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/ocaml-esy-rely.t
+++ b/test_template/lib/ocaml-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/ocaml-opam-alcotest.t
+++ b/test_template/lib/ocaml-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/ocaml-opam-alcotest.t
+++ b/test_template/lib/ocaml-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/ocaml-opam-rely.t
+++ b/test_template/lib/ocaml-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/ocaml-opam-rely.t
+++ b/test_template/lib/ocaml-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/reason-esy-alcotest.t
+++ b/test_template/lib/reason-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/reason-esy-alcotest.t
+++ b/test_template/lib/reason-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/reason-esy-rely.t
+++ b/test_template/lib/reason-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/reason-esy-rely.t
+++ b/test_template/lib/reason-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/reason-opam-alcotest.t
+++ b/test_template/lib/reason-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/reason-opam-alcotest.t
+++ b/test_template/lib/reason-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from lib in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/lib/reason-opam-rely.t
+++ b/test_template/lib/reason-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/lib/reason-opam-rely.t
+++ b/test_template/lib/reason-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/ocaml-esy-alcotest.t
+++ b/test_template/ppx/ocaml-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/ocaml-esy-alcotest.t
+++ b/test_template/ppx/ocaml-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/ocaml-esy-rely.t
+++ b/test_template/ppx/ocaml-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/ocaml-esy-rely.t
+++ b/test_template/ppx/ocaml-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/ocaml-opam-alcotest.t
+++ b/test_template/ppx/ocaml-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/ocaml-opam-alcotest.t
+++ b/test_template/ppx/ocaml-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/ocaml-opam-rely.t
+++ b/test_template/ppx/ocaml-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=OCaml
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/ocaml-opam-rely.t
+++ b/test_template/ppx/ocaml-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/reason-esy-alcotest.t
+++ b/test_template/ppx/reason-esy-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/reason-esy-alcotest.t
+++ b/test_template/ppx/reason-esy-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/reason-esy-rely.t
+++ b/test_template/ppx/reason-esy-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/reason-esy-rely.t
+++ b/test_template/ppx/reason-esy-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/reason-opam-alcotest.t
+++ b/test_template/ppx/reason-opam-alcotest.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/reason-opam-alcotest.t
+++ b/test_template/ppx/reason-opam-alcotest.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated

--- a/test_template/ppx/reason-opam-rely.t
+++ b/test_template/ppx/reason-opam-rely.t
@@ -1,4 +1,5 @@
   $ export OPAMSKIPUPDATE=true
+  $ export SPIN_CREATE_SWITCH=false
   $ export SPIN_PROJECT_NAME=demo
   $ export SPIN_USERNAME=user
   $ export SPIN_SYNTAX=Reason
@@ -16,7 +17,7 @@
 
   Here are some example commands that you can run inside this directory:
 
-    make dev
+    make deps
       Download runtime and development dependencies.
 
     make build

--- a/test_template/ppx/reason-opam-rely.t
+++ b/test_template/ppx/reason-opam-rely.t
@@ -10,7 +10,7 @@
   🏗️  Creating a new project from ppx in _generated
   Done!
 
-  🎁  Installing packages. This might take a couple minutes.
+  🎁  Installing packages globally. This might take a couple minutes.
   Done!
 
   🎉  Success! Your project is ready at _generated


### PR DESCRIPTION
By default, Spin now creates a local switch for the generated projects. This can be changed with `spin config`, or by setting the env variable `SPIN_CREATE_SWITCH=false`