### PR TITLE
Remove selection of OCaml version in `opam switch create`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,7 @@
 
 - The project generation will now fail before the configurations prompt if the output directory is not empty
 - By default, Spin now creates a local switch for the generated projects. This can be changed with `spin config`, or by setting the env variable `SPIN_CREATE_SWITCH=false`
+- Fix an CLI incompatibility between `opam.2.0.X` and `opam.2.1.X` that made Spin unusable with the former.
 
 # 0.7.0
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all:
 
 .PHONY: dev
 dev: ## Install development dependencies
-	opam switch create --no-install . ocaml-base-compiler.4.12.0
+	opam switch create . --no-install
 	opam install -y dune-release ocamlformat utop ocaml-lsp-server
 	opam install --deps-only --with-test --with-doc -y .
 

--- a/template/bin/template/Makefile
+++ b/template/bin/template/Makefile
@@ -20,11 +20,7 @@ deps: ## Install development dependencies
 
 .PHONY: create_switch
 create_switch: ## Create an opam switch without any dependency
-	{%- if syntax == 'Reason' %}
-	opam switch create . 4.10.0 --no-install
-	{%- else %}
 	opam switch create . --no-install
-	{%- endif %}
 
 .PHONY: switch
 switch: ## Create an opam switch and install development dependencies

--- a/template/c-bindings/template/Makefile
+++ b/template/c-bindings/template/Makefile
@@ -20,11 +20,7 @@ deps: ## Install development dependencies
 
 .PHONY: create_switch
 create_switch:
-	{%- if syntax == 'Reason' %}
-	opam switch create . 4.10.0 --no-install
-	{%- else %}
 	opam switch create . --no-install
-	{%- endif %}
 
 .PHONY: switch
 switch: ## Create an opam switch and install development dependencies

--- a/template/cli/template/Makefile
+++ b/template/cli/template/Makefile
@@ -20,11 +20,7 @@ deps: ## Install development dependencies
 
 .PHONY: create_switch
 create_switch: ## Create an opam switch without any dependency
-	{%- if syntax == 'Reason' %}
-	opam switch create . 4.10.0 --no-install
-	{%- else %}
 	opam switch create . --no-install
-	{%- endif %}
 
 .PHONY: switch
 switch: ## Create an opam switch and install development dependencies

--- a/template/js/template/Makefile
+++ b/template/js/template/Makefile
@@ -21,11 +21,7 @@ deps: ## Install development dependencies
 
 .PHONY: create_switch
 create_switch:
-	{%- if syntax == 'Reason' %}
-	opam switch create . 4.10.0 --no-install
-	{%- else %}
 	opam switch create . --no-install
-	{%- endif %}
 
 .PHONY: switch
 switch: ## Create an opam switch and install development dependencies


### PR DESCRIPTION
This removes the selection of the compiler version when creating an Opam switch.
This addresses the CLI incompatibility between `opam.2.0.X` and `opam.2.1.X` reported in #109 (although `main` should not be impacted by this for the OCaml syntax).

Fixes #109 