### PR TITLE
Remove Lwt and Base

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,7 @@ fmt: ## Format the codebase with ocamlformat
 
 .PHONY: watch
 watch: ## Watch for the filesystem and rebuild on every change
-	opam exec -- dune build ---root . -watch
+	opam exec -- dune build --root . --watch
 
 .PHONY: utop
 utop: ## Run a REPL and link with the project's libraries

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ If a value is present in the configuration file, it will not be prompted when ge
 
 See our [development board](https://github.com/tmattio/spin/projects/1) for a list of selected features and issues.
 
+Here are some of the improvements we'll be working on as well in for next releases:
+
+- [ ] Add cram tests to CI
+- [ ] Support Opam 2.0.X (add to CI)
+- [ ] Support windows
+- [ ] Support CLI options/args for configurations
+- [ ] Extract current templates in community templates, and drop support for Reason/Esy
+- [ ] Minimal `hello` template
+- [ ] Generators for `lib/bin/test` for all templates
+
 ## Contributing
 
 We'd love your help improving Spin!

--- a/bin/commands/cmd_config.ml
+++ b/bin/commands/cmd_config.ml
@@ -1,13 +1,12 @@
 open Spin
 
 let run () =
-  let open Result.Let_syntax in
+  let open Result.Syntax in
   let* user_config = User_config.read () in
   let* new_config =
-    let result = User_config.prompt ?default:user_config () in
-    try Ok (Lwt_main.run result) with
-    | Caml.Sys.Break | Failure _ ->
-      Caml.exit 1
+    try Ok (User_config.prompt ?default:user_config ()) with
+    | Sys.Break | Failure _ ->
+      exit 1
     | e ->
       raise e
   in
@@ -43,7 +42,7 @@ let man =
 let info = Term.info "config" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs
 
 let term =
-  let open Common.Let_syntax in
+  let open Common.Syntax in
   let+ _term = Common.term in
   run () |> Common.handle_errors
 

--- a/bin/commands/cmd_gen.ml
+++ b/bin/commands/cmd_gen.ml
@@ -1,7 +1,7 @@
 open Spin
 
 let run ~ignore_config ~use_defaults:_ ~generator =
-  let open Result.Let_syntax in
+  let open Result.Syntax in
   let* context =
     if ignore_config then
       Ok None
@@ -24,17 +24,16 @@ let run ~ignore_config ~use_defaults:_ ~generator =
   | Some project_config ->
     (match generator with
     | None ->
-      let+ generators =
-        Project.project_generators project_config.dec |> Lwt_main.run
-      in
+      let+ generators = Project.project_generators project_config.dec in
       Logs.app (fun m -> m "");
-      List.iter generators ~f:(fun (name, description) ->
+      List.iter
+        (fun (name, description) ->
           Logs.app (fun m -> m "  %a" Pp.pp_blue name);
           Logs.app (fun m -> m "    %s" description);
           Logs.app (fun m -> m ""))
+        generators
     | Some generator ->
-      Project.run_generator ?context ~project:project_config generator
-      |> Lwt_main.run)
+      Project.run_generator ?context ~project:project_config generator)
 
 (* Command line interface *)
 
@@ -71,7 +70,7 @@ let man =
 let info = Term.info "gen" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs
 
 let term =
-  let open Common.Let_syntax in
+  let open Common.Syntax in
   let+ _term = Common.term
   and+ ignore_config = Common.ignore_config_arg
   and+ use_defaults = Common.use_defaults_arg

--- a/bin/commands/cmd_ls.ml
+++ b/bin/commands/cmd_ls.ml
@@ -1,10 +1,11 @@
 open Spin
 
 let run () =
-  let open Result.Let_syntax in
+  let open Result.Syntax in
   let+ templates = Official_template.all_doc () in
   let sorted_templates =
-    List.sort templates ~compare:(fun { name = t1; _ } { name = t2; _ } ->
+    List.sort
+      (fun Official_template.{ name = t1; _ } Official_template.{ name = t2; _ } ->
         if String.equal (String.prefix t1 3) "bs-" then
           if String.equal (String.prefix t2 3) "bs-" then
             String.compare t1 t2
@@ -14,12 +15,15 @@ let run () =
           1
         else
           String.compare t1 t2)
+      templates
   in
   Logs.app (fun m -> m "");
-  List.iter sorted_templates ~f:(fun { name; description } ->
+  List.iter
+    (fun Official_template.{ name; description } ->
       Logs.app (fun m -> m "  %a" Pp.pp_blue name);
       Logs.app (fun m -> m "    %s" description);
       Logs.app (fun m -> m ""))
+    sorted_templates
 
 (* Command line interface *)
 
@@ -45,7 +49,7 @@ let man =
 let info = Term.info "ls" ~doc ~sdocs ~exits ~envs ~man ~man_xrefs
 
 let term =
-  let open Common.Let_syntax in
+  let open Common.Syntax in
   let+ _term = Common.term in
   run () |> Common.handle_errors
 

--- a/bin/common.ml
+++ b/bin/common.ml
@@ -1,12 +1,12 @@
 open Cmdliner
 
-module Let_syntax = struct
+module Syntax = struct
   let ( let+ ) t f = Term.(const f $ t)
 
   let ( and+ ) a b = Term.(const (fun x y -> x, y) $ a $ b)
 end
 
-open Let_syntax
+open Syntax
 
 let ignore_config_arg =
   let doc =

--- a/bin/common.mli
+++ b/bin/common.mli
@@ -10,7 +10,7 @@ val envs : Cmdliner.Term.env_info list
 
 val exits : Cmdliner.Term.exit_info list
 
-module Let_syntax : sig
+module Syntax : sig
   val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
 
   val ( and+ )

--- a/bin/main.ml
+++ b/bin/main.ml
@@ -1,5 +1,7 @@
 open Cmdliner
 
+let () = Printexc.record_backtrace true
+
 let cmds = [ Cmd_config.cmd; Cmd_gen.cmd; Cmd_ls.cmd; Cmd_new.cmd ]
 
 let run () =
@@ -25,7 +27,7 @@ For a complete documentation, refer to the manual with `spin --help`.
 
 Use `spin COMMAND --help` for help on a single command.|}
   in
-  Caml.print_endline message;
+  print_endline message;
   0
 
 (* Command line interface *)
@@ -74,7 +76,7 @@ let man =
 
 let default_cmd =
   let term =
-    let open Common.Let_syntax in
+    let open Common.Syntax in
     let+ _term = Common.term in
     run ()
   in

--- a/dune-project
+++ b/dune-project
@@ -29,14 +29,14 @@
   (reason :with-test)
   (odoc :with-doc)
   (crunch :build)
-  base
+  (sexplib0
+   (>= v0.13))
+  (inquire
+   (>= 0.3.0))
+  (spawn
+   (>= v0.13))
   fmt
   fpath
   cmdliner
   logs
-  sexplib
-  (lwt
-   (>= 5.3.0))
-  jingoo
-  (inquire
-   (>= 0.2.1))))
+  jingoo))

--- a/lib/spin/config.ml
+++ b/lib/spin/config.ml
@@ -1,31 +1,31 @@
 let default_cache_dir =
   match Sys.os_type with
   | "Unix" ->
-    Sys.getenv "HOME"
-    |> Result.of_option ~error:(`Missing_env_var "HOME")
-    |> Result.map ~f:(fun home -> Filename.of_parts [ home; ".cache"; "spin" ])
+    Sys.getenv_opt "HOME"
+    |> Option.to_result ~none:(`Missing_env_var "HOME")
+    |> Result.map (fun home -> Filename.of_parts [ home; ".cache"; "spin" ])
   | _ ->
-    Sys.getenv "APPDATA"
-    |> Result.of_option ~error:(`Missing_env_var "APPDATA")
-    |> Result.map ~f:(fun home -> Filename.of_parts [ home; "spin"; "cache" ])
+    Sys.getenv_opt "APPDATA"
+    |> Option.to_result ~none:(`Missing_env_var "APPDATA")
+    |> Result.map (fun home -> Filename.of_parts [ home; "spin"; "cache" ])
 
 let default_config_dir =
   match Sys.os_type with
   | "Unix" ->
-    Sys.getenv "HOME"
-    |> Result.of_option ~error:(`Missing_env_var "HOME")
-    |> Result.map ~f:(fun home -> Filename.of_parts [ home; ".config"; "spin" ])
+    Sys.getenv_opt "HOME"
+    |> Option.to_result ~none:(`Missing_env_var "HOME")
+    |> Result.map (fun home -> Filename.of_parts [ home; ".config"; "spin" ])
   | _ ->
-    Sys.getenv "APPDATA"
-    |> Result.of_option ~error:(`Missing_env_var "APPDATA")
-    |> Result.map ~f:(fun home -> Filename.of_parts [ home; "spin"; "config" ])
+    Sys.getenv_opt "APPDATA"
+    |> Option.to_result ~none:(`Missing_env_var "APPDATA")
+    |> Result.map (fun home -> Filename.of_parts [ home; "spin"; "config" ])
 
 let spin_cache_dir =
-  Sys.getenv "SPIN_CACHE_DIR"
-  |> Option.map ~f:Result.return
+  Sys.getenv_opt "SPIN_CACHE_DIR"
+  |> Option.map Result.ok
   |> Option.value ~default:default_cache_dir
 
 let spin_config_dir =
-  Sys.getenv "SPIN_CONFIG_DIR"
-  |> Option.map ~f:Result.return
+  Sys.getenv_opt "SPIN_CONFIG_DIR"
+  |> Option.map Result.ok
   |> Option.value ~default:default_config_dir

--- a/lib/spin/decoder.mli
+++ b/lib/spin/decoder.mli
@@ -1,6 +1,8 @@
 (* This module is heavily inspired by
    https://github.com/mattjbray/ocaml-decoders/ *)
 
+open Sexplib0
+
 type error =
   | Decoder_error of string * Sexp.t option
   | Decoder_errors of error list
@@ -10,7 +12,7 @@ type 'a t = Sexp.t -> ('a, error) Result.t
 
 (** {2 Error handling} *)
 
-val pp_error : Formatter.t -> error -> unit
+val pp_error : Format.formatter -> error -> unit
 (** Pretty-print an [error]. *)
 
 val string_of_error : error -> string
@@ -58,19 +60,19 @@ val list : 'a t -> 'a list t
 
 (** {2 Decoding records} *)
 
-val field : f:'a t -> string -> 'a t
+val field : string -> 'a t -> 'a t
 (** Decode a record from the field with the given name.
 
     This will fail with an error if the field could not be found. It will also
     fail if several fields exist with the same name. Use [fields] if you want to
     decode a list of fields. *)
 
-val fields : f:'a t -> string -> 'a list t
+val fields : string -> 'a t -> 'a list t
 (** Decode a list of record from the fields with the given name.
 
     It returns an empty list if no fields with the given name exist. *)
 
-val field_opt : f:'a t -> string -> 'a option t
+val field_opt : string -> 'a t -> 'a option t
 (** Decode a record from the field with the given name.
 
     This will return [None] if the field could not be found. It will fail if
@@ -91,10 +93,10 @@ val one_of : (string * 'a t) list -> 'a t
 val return : 'a -> 'a t
 (** Lift decoder from a value. *)
 
-val map : f:('a -> 'b) -> 'a t -> 'b t
+val map : ('a -> 'b) -> 'a t -> 'b t
 (** Map over the output of a decoder. *)
 
-val bind : f:('a -> 'b t) -> 'a t -> 'b t
+val bind : 'a t -> ('a -> 'b t) -> 'b t
 (** Create decoders that depend on previous outputs. *)
 
 val product : 'a t -> 'b t -> ('a * 'b) t
@@ -111,7 +113,7 @@ end
 
 include module type of Infix
 
-module Let_syntax : sig
+module Syntax : sig
   val ( let* ) : 'a t -> ('a -> 'b t) -> 'b t
 
   val ( let+ ) : 'a t -> ('a -> 'b) -> 'b t
@@ -119,21 +121,21 @@ module Let_syntax : sig
   val ( and+ ) : 'a t -> 'b t -> ('a * 'b) t
 end
 
-include module type of Let_syntax
+include module type of Syntax
 
 (** {2 Running decoders} *)
 
-val decode_sexp : f:'a t -> Sexp.t -> ('a, error) Result.t
+val decode_sexp : Sexp.t -> 'a t -> ('a, error) Result.t
 (** Run a decoder on some input. *)
 
-val decode_string : f:'a t -> string -> ('a, error) Result.t
+val decode_string : string -> 'a t -> ('a, error) Result.t
 (** Run a decoder on a string. *)
 
-val decode_sexps_string : f:'a t -> string -> ('a, error) Result.t
+val decode_sexps_string : string -> 'a t -> ('a, error) Result.t
 (** Run a decoder on a string containing a list of s-expression. *)
 
-val decode_file : f:'a t -> string -> ('a, error) Result.t
+val decode_file : string -> 'a t -> ('a, error) Result.t
 (** Run a decoder on a file. *)
 
-val decode_sexps_file : f:'a t -> string -> ('a, error) Result.t
+val decode_sexps_file : string -> 'a t -> ('a, error) Result.t
 (** Run a decoder on a file containing a list of s-expression. *)

--- a/lib/spin/decoders/dec_common.ml
+++ b/lib/spin/decoders/dec_common.ml
@@ -40,21 +40,21 @@ module Source = struct
     let open Decoder in
     one_of
       [ ( "official"
-        , let+ v = field "official" ~f:Template_name.decode in
+        , let+ v = field "official" Template_name.decode in
           Official v )
       ; ( "local"
-        , let+ v = field "local" ~f:string in
+        , let+ v = field "local" string in
           Local_dir v )
       ; ( "git"
-        , let+ v = field "git" ~f:Git_repo.decode in
+        , let+ v = field "git" Git_repo.decode in
           Local_dir v )
       ]
 
   let encode = function
     | Git v ->
-      Sexp.List [ Sexp.Atom "git"; Sexp.Atom v ]
+      Sexplib.Sexp.List [ Sexplib.Sexp.Atom "git"; Sexplib.Sexp.Atom v ]
     | Local_dir v ->
-      Sexp.List [ Sexp.Atom "local"; Sexp.Atom v ]
+      Sexplib.Sexp.List [ Sexplib.Sexp.Atom "local"; Sexplib.Sexp.Atom v ]
     | Official v ->
-      Sexp.List [ Sexp.Atom "official"; Sexp.Atom v ]
+      Sexplib.Sexp.List [ Sexplib.Sexp.Atom "official"; Sexplib.Sexp.Atom v ]
 end

--- a/lib/spin/decoders/dec_project.ml
+++ b/lib/spin/decoders/dec_project.ml
@@ -13,27 +13,32 @@ module Config = struct
 
   let decode sexp =
     match sexp with
-    | Sexp.List [ Sexp.Atom config_name; Sexp.Atom config_value ] ->
+    | Sexplib.Sexp.List
+        [ Sexplib.Sexp.Atom config_name; Sexplib.Sexp.Atom config_value ] ->
       Ok (config_name, config_value)
     | _ ->
       Error (Decoder.Decoder_error (Errors.unexpected_format, Some sexp))
 
   let encode (config_name, config_value) =
-    Sexp.List [ Sexp.Atom config_name; Sexp.Atom config_value ]
+    Sexplib.Sexp.List
+      [ Sexplib.Sexp.Atom config_name; Sexplib.Sexp.Atom config_value ]
 end
 
 let decode =
-  let open Decoder.Let_syntax in
-  let+ source = Decoder.field "source" ~f:Source.decode
-  and+ configs = Decoder.fields "config" ~f:Config.decode in
+  let open Decoder.Syntax in
+  let+ source = Decoder.field "source" Source.decode
+  and+ configs = Decoder.fields "config" Config.decode in
   { source; configs }
 
 let encode t =
-  Sexp.List
-    ([ Sexp.List [ Sexp.Atom "source"; Source.encode t.source ] ]
-    @ List.map t.configs ~f:(fun (config_name, config_value) ->
-          Sexp.List
-            [ Sexp.Atom "config"
-            ; Sexp.Atom config_name
-            ; Sexp.Atom config_value
-            ]))
+  Sexplib.Sexp.List
+    ([ Sexplib.Sexp.List [ Sexplib.Sexp.Atom "source"; Source.encode t.source ]
+     ]
+    @ List.map
+        (fun (config_name, config_value) ->
+          Sexplib.Sexp.List
+            [ Sexplib.Sexp.Atom "config"
+            ; Sexplib.Sexp.Atom config_name
+            ; Sexplib.Sexp.Atom config_value
+            ])
+        t.configs)

--- a/lib/spin/decoders/dec_template.ml
+++ b/lib/spin/decoders/dec_template.ml
@@ -32,39 +32,35 @@ module Base_template = struct
 
   let decode_overwrite sexp =
     match sexp with
-    | Sexp.Atom "configs" ->
+    | Sexplib.Sexp.Atom "configs" ->
       Ok Configs
-    | Sexp.Atom "actions" ->
+    | Sexplib.Sexp.Atom "actions" ->
       Ok Actions
-    | Sexp.Atom "example_commands" ->
+    | Sexplib.Sexp.Atom "example_commands" ->
       Ok Example_commands
-    | Sexp.Atom "generators" ->
+    | Sexplib.Sexp.Atom "generators" ->
       Ok Generators
-    | Sexp.Atom _ ->
+    | Sexplib.Sexp.Atom _ ->
       decoder_error ~msg:Errors.invalid_overwite sexp
-    | Sexp.List _ ->
+    | Sexplib.Sexp.List _ ->
       decoder_error ~msg:Errors.expected_string sexp
 
   let decode =
     let open Decoder in
     let+ source = Source.decode
-    and+ overwrites = field_opt "overwrites" ~f:(list decode_overwrite) in
+    and+ overwrites = field_opt "overwrites" (list decode_overwrite) in
     let overwrites = Option.value overwrites ~default:[] in
     let ignore_configs =
-      List.exists overwrites ~f:(function Configs -> true | _ -> false)
+      List.exists (function Configs -> true | _ -> false) overwrites
     in
     let ignore_actions =
-      List.exists overwrites ~f:(function Actions -> true | _ -> false)
+      List.exists (function Actions -> true | _ -> false) overwrites
     in
     let ignore_example_commands =
-      List.exists overwrites ~f:(function
-          | Example_commands ->
-            true
-          | _ ->
-            false)
+      List.exists (function Example_commands -> true | _ -> false) overwrites
     in
     let ignore_generators =
-      List.exists overwrites ~f:(function Generators -> true | _ -> false)
+      List.exists (function Generators -> true | _ -> false) overwrites
     in
     { source
     ; ignore_configs
@@ -86,7 +82,7 @@ module Raw_files = struct
   let decode =
     Decoder.one_of
       [ "n files", Decoder.list Decoder.string
-      ; "one file", Decoder.map ~f:List.return Decoder.string
+      ; "one file", Decoder.map (fun x -> [ x ]) Decoder.string
       ]
 end
 
@@ -115,50 +111,58 @@ module Expr = struct
     | Concat of t list
 
   let rec decode = function
-    | Sexp.Atom s when String.equal (String.prefix s 1) ":" ->
+    | Sexplib.Sexp.Atom s when String.equal (String.prefix s 1) ":" ->
       Ok (Var (String.drop_prefix s 1))
-    | Sexp.Atom s when String.equal (String.prefix s 2) "\\:" ->
+    | Sexplib.Sexp.Atom s when String.equal (String.prefix s 2) "\\:" ->
       Ok (String (String.drop_prefix s 1))
-    | Sexp.Atom s ->
+    | Sexplib.Sexp.Atom s ->
       Ok (String s)
-    | Sexp.List (Sexp.Atom ("if" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("if" as name) :: args) as sexp ->
       decode_fn3 name args ~sexp ~ctor:(fun a b c -> If (a, b, c))
-    | Sexp.List (Sexp.Atom ("and" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("and" as name) :: args) as sexp ->
       decode_fn2 name args ~sexp ~ctor:(fun a b -> And (a, b))
-    | Sexp.List (Sexp.Atom ("or" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("or" as name) :: args) as sexp ->
       decode_fn2 name args ~sexp ~ctor:(fun a b -> Or (a, b))
-    | Sexp.List (Sexp.Atom ("eq" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("eq" as name) :: args) as sexp ->
       decode_fn2 name args ~sexp ~ctor:(fun a b -> Eq (a, b))
-    | Sexp.List (Sexp.Atom ("neq" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("neq" as name) :: args) as sexp ->
       decode_fn2 name args ~sexp ~ctor:(fun a b -> Neq (a, b))
-    | Sexp.List (Sexp.Atom ("not" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("not" as name) :: args) as sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Not a)
-    | Sexp.List (Sexp.Atom ("slugify" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("slugify" as name) :: args) as sexp
+      ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Slugify a)
-    | Sexp.List (Sexp.Atom ("upper" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("upper" as name) :: args) as sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Upper a)
-    | Sexp.List (Sexp.Atom ("lower" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("lower" as name) :: args) as sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Lower a)
-    | Sexp.List (Sexp.Atom ("snake_case" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("snake_case" as name) :: args) as
+      sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Snake_case a)
-    | Sexp.List (Sexp.Atom ("camel_case" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("camel_case" as name) :: args) as
+      sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Camel_case a)
-    | Sexp.List (Sexp.Atom ("trim" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("trim" as name) :: args) as sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Trim a)
-    | Sexp.List (Sexp.Atom ("first_char" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("first_char" as name) :: args) as
+      sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> First_char a)
-    | Sexp.List (Sexp.Atom ("last_char" as name) :: args) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("last_char" as name) :: args) as
+      sexp ->
       decode_fn1 name args ~sexp ~ctor:(fun a -> Last_char a)
-    | Sexp.List (Sexp.Atom ("run" as name) :: args) as sexp ->
-      let open Result.Let_syntax in
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom ("run" as name) :: args) as sexp ->
+      let open Result.Syntax in
       (match args with
       | e1 :: rest ->
         let+ d1 = decode e1
         and+ d2 =
-          List.fold_left rest ~init:(Ok []) ~f:(fun acc el ->
+          List.fold_left
+            (fun acc el ->
               let* acc = acc in
               let+ decoded = decode el in
               decoded :: acc)
+            (Ok [])
+            rest
         in
         Function (Run (d1, d2))
       | _ ->
@@ -168,26 +172,30 @@ module Expr = struct
                "The function %S expected exactly one argument."
                name)
           sexp)
-    | Sexp.List (Sexp.Atom "concat" :: args) ->
-      let open Result.Let_syntax in
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom "concat" :: args) ->
+      let open Result.Syntax in
       let+ d_args =
-        List.fold_left args ~init:(Ok []) ~f:(fun acc el ->
+        List.fold_left
+          (fun acc el ->
             let* acc = acc in
             let+ decoded = decode el in
             decoded :: acc)
+          (Ok [])
+          args
       in
       Function (Concat (List.rev d_args))
-    | Sexp.List (Sexp.Atom fn :: _) as sexp ->
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom fn :: _) as sexp ->
       decoder_error
         ~msg:(Printf.sprintf "The function %S does not exist." fn)
         sexp
-    | (Sexp.List (Sexp.List _ :: _) | Sexp.List []) as sexp ->
+    | (Sexplib.Sexp.List (Sexplib.Sexp.List _ :: _) | Sexplib.Sexp.List []) as
+      sexp ->
       decoder_error
         ~msg:(Printf.sprintf "The expression does not have a valid format.")
         sexp
 
   and decode_fn1 ~sexp ~ctor name =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     function
     | [ e1 ] ->
       let+ d1 = decode e1 in
@@ -199,7 +207,7 @@ module Expr = struct
         sexp
 
   and decode_fn2 ~sexp ~ctor name =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     function
     | [ e1; e2 ] ->
       let+ d1 = decode e1
@@ -214,7 +222,7 @@ module Expr = struct
         sexp
 
   and decode_fn3 ~sexp ~ctor name =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     function
     | [ e1; e2; e3 ] ->
       let+ d1 = decode e1
@@ -259,32 +267,32 @@ module Configuration = struct
     }
 
   let decode_input =
-    let open Decoder.Let_syntax in
-    let+ message = Decoder.field "prompt" ~f:Decoder.string in
+    let open Decoder.Syntax in
+    let+ message = Decoder.field "prompt" Decoder.string in
     Input { message }
 
   let decode_select =
-    let open Decoder.Let_syntax in
-    let+ message = Decoder.field "prompt" ~f:Decoder.string
-    and+ values = Decoder.field "values" ~f:Decoder.(list string) in
+    let open Decoder.Syntax in
+    let+ message = Decoder.field "prompt" Decoder.string
+    and+ values = Decoder.field "values" Decoder.(list string) in
     Select { message; values }
 
   let decode_confirm =
-    let open Decoder.Let_syntax in
-    let+ message = Decoder.field "prompt" ~f:Decoder.string in
+    let open Decoder.Syntax in
+    let+ message = Decoder.field "prompt" Decoder.string in
     Confirm { message }
 
   let decode_prompt =
     Decoder.one_of_opt
-      [ "input", Decoder.field "input" ~f:decode_input
-      ; "select", Decoder.field "select" ~f:decode_select
-      ; "confirm", Decoder.field "confirm" ~f:decode_confirm
+      [ "input", Decoder.field "input" decode_input
+      ; "select", Decoder.field "select" decode_select
+      ; "confirm", Decoder.field "confirm" decode_confirm
       ]
 
   let decode_rule =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     function
-    | Sexp.List [ message; expr ] ->
+    | Sexplib.Sexp.List [ message; expr ] ->
       let+ message = Expr.decode message
       and+ expr = Expr.decode expr in
       { message; expr }
@@ -296,22 +304,21 @@ module Configuration = struct
         sexp
 
   let decode = function
-    | Sexp.List (Sexp.Atom name :: rest) ->
-      let open Result.Let_syntax in
-      let optional_fields = Sexp.List rest in
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom name :: rest) ->
+      let open Result.Syntax in
+      let optional_fields = Sexplib.Sexp.List rest in
       let+ prompt = decode_prompt optional_fields
-      and+ default = Decoder.field_opt "default" ~f:Expr.decode optional_fields
+      and+ default = Decoder.field_opt "default" Expr.decode optional_fields
       and+ rules =
         Decoder.field_opt
           "rules"
-          ~f:
-            (Decoder.one_of
-               [ "n rules", Decoder.list decode_rule
-               ; "one rule", Decoder.map ~f:List.return decode_rule
-               ])
+          (Decoder.one_of
+             [ "n rules", Decoder.list decode_rule
+             ; "one rule", Decoder.map (fun x -> [ x ]) decode_rule
+             ])
           optional_fields
       and+ enabled_if =
-        Decoder.field_opt "enabled_if" ~f:Expr.decode optional_fields
+        Decoder.field_opt "enabled_if" Expr.decode optional_fields
       in
       let rules = Option.value rules ~default:[] in
       { name; prompt; default; rules; enabled_if }
@@ -340,11 +347,11 @@ module Actions = struct
     }
 
   let decode_run_action =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     function
-    | Sexp.List (Sexp.Atom name :: rest) ->
-      let+ args = Decoder.list Decoder.string (Sexp.List rest) in
-      Run { name; args }
+    | Sexplib.Sexp.List (Sexplib.Sexp.Atom name :: rest) ->
+      let+ args = Decoder.list Decoder.string (Sexplib.Sexp.List rest) in
+      Run { name = String.trim name; args = List.map String.trim args }
     | sexp ->
       decoder_error
         ~msg:
@@ -353,10 +360,10 @@ module Actions = struct
         sexp
 
   let decode_refmt_action sexp =
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     let+ files =
       Decoder.one_of
-        [ "string", Decoder.map Expr.decode ~f:List.return
+        [ "string", Decoder.map (fun x -> [ x ]) Expr.decode
         ; ("string list", Decoder.(list Expr.decode))
         ]
         sexp
@@ -365,22 +372,21 @@ module Actions = struct
 
   let decode_action =
     Decoder.one_of
-      [ "run", Decoder.field "run" ~f:decode_run_action
-      ; "refmt", Decoder.field "refmt" ~f:decode_refmt_action
+      [ "run", Decoder.field "run" decode_run_action
+      ; "refmt", Decoder.field "refmt" decode_refmt_action
       ]
 
   let decode =
-    let open Decoder.Let_syntax in
+    let open Decoder.Syntax in
     let+ actions =
       Decoder.field
         "actions"
-        ~f:
-          (Decoder.one_of
-             [ "n actions", Decoder.list decode_action
-             ; "one action", Decoder.map ~f:List.return decode_action
-             ])
-    and+ message = Decoder.field_opt "message" ~f:Expr.decode
-    and+ enabled_if = Decoder.field_opt "enabled_if" ~f:Expr.decode in
+        (Decoder.one_of
+           [ "n actions", Decoder.list decode_action
+           ; "one action", Decoder.map (fun x -> [ x ]) decode_action
+           ])
+    and+ message = Decoder.field_opt "message" Expr.decode
+    and+ enabled_if = Decoder.field_opt "enabled_if" Expr.decode in
     { actions; message; enabled_if }
 end
 
@@ -393,14 +399,14 @@ module Ignore_rule = struct
   let decode_files sexp =
     Decoder.one_of
       [ ("string list", Decoder.(list string))
-      ; "string", Decoder.map Decoder.string ~f:List.return
+      ; "string", Decoder.map (fun x -> [ x ]) Decoder.string
       ]
       sexp
 
   let decode =
-    let open Decoder.Let_syntax in
-    let+ files = Decoder.field "files" ~f:decode_files
-    and+ enabled_if = Decoder.field_opt "enabled_if" ~f:Expr.decode in
+    let open Decoder.Syntax in
+    let+ files = Decoder.field "files" decode_files
+    and+ enabled_if = Decoder.field_opt "enabled_if" Expr.decode in
     { files; enabled_if }
 end
 
@@ -412,10 +418,10 @@ module Example_command = struct
     }
 
   let decode =
-    let open Decoder.Let_syntax in
-    let+ name = Decoder.field "name" ~f:Decoder.string
-    and+ description = Decoder.field "description" ~f:Decoder.string
-    and+ enabled_if = Decoder.field_opt "enabled_if" ~f:Expr.decode in
+    let open Decoder.Syntax in
+    let+ name = Decoder.field "name" Decoder.string
+    and+ description = Decoder.field "description" Decoder.string
+    and+ enabled_if = Decoder.field_opt "enabled_if" Expr.decode in
     { name; description; enabled_if }
 end
 
@@ -428,7 +434,8 @@ module Example_commands = struct
     }
 
   let decode_command = function
-    | Sexp.List [ Sexp.Atom name; Sexp.Atom description ] ->
+    | Sexplib.Sexp.List
+        [ Sexplib.Sexp.Atom name; Sexplib.Sexp.Atom description ] ->
       Ok { name; description }
     | sexp ->
       decoder_error
@@ -438,12 +445,14 @@ module Example_commands = struct
   let decode_commands = Decoder.list decode_command
 
   let decode =
-    let open Decoder.Let_syntax in
-    let+ commands = Decoder.field "commands" ~f:decode_commands
-    and+ enabled_if = Decoder.field_opt "enabled_if" ~f:Expr.decode in
-    List.map commands ~f:(fun cmd ->
+    let open Decoder.Syntax in
+    let+ (commands : command list) = Decoder.field "commands" decode_commands
+    and+ enabled_if = Decoder.field_opt "enabled_if" Expr.decode in
+    List.map
+      (fun (cmd : command) ->
         Example_command.
           { name = cmd.name; description = cmd.description; enabled_if })
+      commands
 end
 
 module Generator = struct
@@ -463,8 +472,8 @@ module Generator = struct
     }
 
   let decode_file = function
-    | Sexp.List [ Sexp.Atom source; destination ] ->
-      let open Result.Let_syntax in
+    | Sexplib.Sexp.List [ Sexplib.Sexp.Atom source; destination ] ->
+      let open Result.Syntax in
       let+ destination = Expr.decode destination in
       { source; destination }
     | sexp ->
@@ -475,18 +484,18 @@ module Generator = struct
   let decode_files =
     Decoder.one_of
       [ "n files", Decoder.list decode_file
-      ; "one file", Decoder.map ~f:List.return decode_file
+      ; "one file", Decoder.map (fun x -> [ x ]) decode_file
       ]
 
   let decode =
-    let open Decoder.Let_syntax in
-    let+ name = Decoder.field "name" ~f:Template_name.decode
-    and+ description = Decoder.field "description" ~f:Description.decode
-    and+ configurations = Decoder.fields "config" ~f:Configuration.decode
-    and+ pre_gen_actions = Decoder.fields "pre_gen" ~f:Actions.decode
-    and+ post_gen_actions = Decoder.fields "post_gen" ~f:Actions.decode
-    and+ files = Decoder.field_opt "files" ~f:decode_files
-    and+ message = Decoder.field_opt "message" ~f:Expr.decode in
+    let open Decoder.Syntax in
+    let+ name = Decoder.field "name" Template_name.decode
+    and+ description = Decoder.field "description" Description.decode
+    and+ configurations = Decoder.fields "config" Configuration.decode
+    and+ pre_gen_actions = Decoder.fields "pre_gen" Actions.decode
+    and+ post_gen_actions = Decoder.fields "post_gen" Actions.decode
+    and+ files = Decoder.field_opt "files" decode_files
+    and+ message = Decoder.field_opt "message" Expr.decode in
     { name
     ; description
     ; configurations
@@ -512,22 +521,21 @@ type t =
   }
 
 let decode =
-  let open Decoder.Let_syntax in
-  let+ name = Decoder.field "name" ~f:Template_name.decode
-  and+ description = Decoder.field "description" ~f:Description.decode
-  and+ base_template = Decoder.field_opt "inherit" ~f:Base_template.decode
-  and+ parse_binaries =
-    Decoder.field_opt "parse_binaries" ~f:Parse_binaries.decode
-  and+ raw_files = Decoder.field_opt "raw_files" ~f:Raw_files.decode
-  and+ configurations = Decoder.fields "config" ~f:Configuration.decode
-  and+ pre_gen_actions = Decoder.fields "pre_gen" ~f:Actions.decode
-  and+ post_gen_actions = Decoder.fields "post_gen" ~f:Actions.decode
-  and+ ignore_file_rules = Decoder.fields "ignore" ~f:Ignore_rule.decode
+  let open Decoder.Syntax in
+  let+ name = Decoder.field "name" Template_name.decode
+  and+ description = Decoder.field "description" Description.decode
+  and+ base_template = Decoder.field_opt "inherit" Base_template.decode
+  and+ parse_binaries = Decoder.field_opt "parse_binaries" Parse_binaries.decode
+  and+ raw_files = Decoder.field_opt "raw_files" Raw_files.decode
+  and+ configurations = Decoder.fields "config" Configuration.decode
+  and+ pre_gen_actions = Decoder.fields "pre_gen" Actions.decode
+  and+ post_gen_actions = Decoder.fields "post_gen" Actions.decode
+  and+ ignore_file_rules = Decoder.fields "ignore" Ignore_rule.decode
   and+ example_commands_list =
-    Decoder.fields "example_commands" ~f:Example_commands.decode
+    Decoder.fields "example_commands" Example_commands.decode
   and+ example_command_list =
-    Decoder.fields "example_command" ~f:Example_command.decode
-  and+ generators = Decoder.fields "generator" ~f:Generator.decode in
+    Decoder.fields "example_command" Example_command.decode
+  and+ generators = Decoder.fields "generator" Generator.decode in
   let example_commands =
     example_command_list @ List.concat example_commands_list
   in

--- a/lib/spin/decoders/dec_user_config.ml
+++ b/lib/spin/decoders/dec_user_config.ml
@@ -6,11 +6,11 @@ type t =
   }
 
 let decode =
-  let open Decoder.Let_syntax in
-  let+ username = Decoder.field_opt "username" ~f:Decoder.string
-  and+ email = Decoder.field_opt "email" ~f:Decoder.string
-  and+ github_username = Decoder.field_opt "github_username" ~f:Decoder.string
-  and+ create_switch = Decoder.field_opt "create_switch" ~f:Decoder.bool in
+  let open Decoder.Syntax in
+  let+ username = Decoder.field_opt "username" Decoder.string
+  and+ email = Decoder.field_opt "email" Decoder.string
+  and+ github_username = Decoder.field_opt "github_username" Decoder.string
+  and+ create_switch = Decoder.field_opt "create_switch" Decoder.bool in
   { username; email; github_username; create_switch }
 
 let encode t =

--- a/lib/spin/decoders/dec_user_config.mli
+++ b/lib/spin/decoders/dec_user_config.mli
@@ -1,0 +1,10 @@
+type t =
+  { username : string option
+  ; email : string option
+  ; github_username : string option
+  ; create_switch : bool option
+  }
+
+val decode : t Decoder.t
+
+val encode : t Encoder.t

--- a/lib/spin/dune
+++ b/lib/spin/dune
@@ -1,8 +1,7 @@
 (library
  (name spin)
  (public_name spin)
- (libraries spin_std spin_template inquire sexplib str fmt logs logs.lwt
-   jingoo fpath)
+ (libraries spin_std spin_template inquire sexplib str fmt logs jingoo fpath)
  (flags
   (:standard -open Spin_std)))
 

--- a/lib/spin/encoder.ml
+++ b/lib/spin/encoder.ml
@@ -1,35 +1,35 @@
+open Sexplib0
+
 type 'a t = 'a -> Sexp.t
 
-let string = Sexplib.Conv.sexp_of_string
+let string = Sexp_conv.sexp_of_string
 
-let int = Sexplib.Conv.sexp_of_int
+let int = Sexp_conv.sexp_of_int
 
-let float = Sexplib.Conv.sexp_of_float
+let float = Sexp_conv.sexp_of_float
 
-let bool = Sexplib.Conv.sexp_of_bool
+let bool = Sexp_conv.sexp_of_bool
 
-let null = Sexplib.Conv.sexp_of_unit ()
+let null = Sexp_conv.sexp_of_unit ()
 
 let nullable encoder = function None -> null | Some x -> encoder x
 
-let list encoder xs = Sexplib.Conv.sexp_of_list (fun x -> encoder x) xs
+let list encoder xs = Sexp_conv.sexp_of_list (fun x -> encoder x) xs
 
-let obj xs =
-  Sexp.List (List.map xs ~f:(fun (k, v) -> Sexp.List [ string k; v ]))
+let obj xs = Sexp.List (List.map (fun (k, v) -> Sexp.List [ string k; v ]) xs)
 
-let encode_sexp ~f x = f x
+let encode_sexp x f = f x
 
-let encode_string ~f x = f x |> Sexplib.Sexp.to_string_hum ~indent:1
+let encode_string x f = f x |> Sexp.to_string_hum ~indent:1
 
-let encode_sexps_string ~f x =
+let encode_sexps_string x f =
   match f x with
   | Sexp.Atom _ as sexp ->
-    Sexplib.Sexp.to_string_hum sexp ~indent:1
+    Sexp.to_string_hum sexp ~indent:1
   | Sexp.List sexps ->
-    List.map sexps ~f:(Sexplib.Sexp.to_string_hum ~indent:1)
-    |> String.concat ~sep:"\n\n"
+    List.map (Sexp.to_string_hum ~indent:1) sexps |> String.concat "\n\n"
 
-let encode_file ~f ~path x =
+let encode_file path x f =
   match f x with
   | Sexp.Atom _ as sexp ->
     Sexplib.Sexp.save_hum path sexp

--- a/lib/spin/encoder.mli
+++ b/lib/spin/encoder.mli
@@ -1,4 +1,4 @@
-type 'a t = 'a -> Sexp.t
+type 'a t = 'a -> Sexplib.Sexp.t
 
 val string : string t
 
@@ -8,18 +8,18 @@ val float : float t
 
 val bool : bool t
 
-val null : Sexp.t
+val null : Sexplib.Sexp.t
 
 val nullable : 'a t -> 'a option t
 
 val list : 'a t -> 'a list t
 
-val obj : (string * Sexp.t) list t
+val obj : (string * Sexplib.Sexp.t) list t
 
-val encode_sexp : f:'a t -> 'a -> Sexp.t
+val encode_sexp : 'a -> 'a t -> Sexplib.Sexp.t
 
-val encode_string : f:'a t -> 'a -> string
+val encode_string : 'a -> 'a t -> string
 
-val encode_sexps_string : f:'a t -> 'a -> string
+val encode_sexps_string : 'a -> 'a t -> string
 
-val encode_file : f:'a t -> path:string -> 'a -> unit
+val encode_file : string -> 'a -> 'a t -> unit

--- a/lib/spin/file_generator.mli
+++ b/lib/spin/file_generator.mli
@@ -1,14 +1,14 @@
 val copy
-  :  context:(string, string) Spin_std.Hashtbl.t
+  :  context:(string, string) Hashtbl.t
   -> content:string
   -> string
-  -> (unit, Spin_error.t) Lwt_result.t
+  -> (unit, Spin_error.t) Result.t
 
 val generate
-  :  context:(string, string) Spin_std.Hashtbl.t
+  :  context:(string, string) Hashtbl.t
   -> content:string
   -> string
-  -> (unit, Spin_error.t) Lwt_result.t
+  -> (unit, Spin_error.t) Result.t
 
 val normalize_path : string -> string
 

--- a/lib/spin/helpers.ml
+++ b/lib/spin/helpers.ml
@@ -1,19 +1,19 @@
 let slugify value =
   value
   |> Str.global_replace (Str.regexp " ") "-"
-  |> String.lowercase
+  |> String.lowercase_ascii
   |> Str.global_replace (Str.regexp "[^a-z0-9\\-]") ""
 
 let snake_case value =
   value
-  |> String.substr_replace_all ~pattern:"-" ~with_:"_"
-  |> String.substr_replace_all ~pattern:" " ~with_:"_"
+  |> Str.global_replace (Str.regexp "-") "_"
+  |> Str.global_replace (Str.regexp " ") "_"
   |> Str.global_replace (Str.regexp "\\([^_A-Z]\\)\\([A-Z]\\)") "\\1_\\2"
-  |> String.lowercase
+  |> String.lowercase_ascii
 
 let camel_case value =
   value
   |> Str.global_substitute
        (Str.regexp "^\\([a-z]\\)\\|[_\\-]\\([a-z]\\)")
-       (fun s -> String.uppercase (Str.matched_string s))
+       (fun s -> String.uppercase_ascii (Str.matched_string s))
   |> Str.global_replace (Str.regexp "[_\\-]") ""

--- a/lib/spin/pp.ml
+++ b/lib/spin/pp.ml
@@ -1,11 +1,11 @@
-let pp_blue : string Fmt.t =
+let pp_blue : Format.formatter -> string -> unit =
   let open Fmt in
   styled (`Fg `Blue) Fmt.string |> styled `Bold
 
-let pp_yellow : string Fmt.t =
+let pp_yellow : Format.formatter -> string -> unit =
   let open Fmt in
   styled (`Fg `Yellow) Fmt.string |> styled `Bold
 
-let pp_bright_green : string Fmt.t =
+let pp_bright_green : Format.formatter -> string -> unit =
   let open Fmt in
   styled (`Fg (`Hi `Green)) Fmt.string |> styled `Bold

--- a/lib/spin/pp.mli
+++ b/lib/spin/pp.mli
@@ -1,0 +1,5 @@
+val pp_blue : Format.formatter -> string -> unit
+
+val pp_yellow : Format.formatter -> string -> unit
+
+val pp_bright_green : Format.formatter -> string -> unit

--- a/lib/spin/project.ml
+++ b/lib/spin/project.ml
@@ -5,7 +5,7 @@ type t =
 
 let project_root () =
   let rec aux dir =
-    if Caml.Sys.file_exists (Filename.concat dir ".spin") then
+    if Sys.file_exists (Filename.concat dir ".spin") then
       Some dir
     else
       let dirname = Filename.dirname dir in
@@ -14,7 +14,7 @@ let project_root () =
       else
         aux dirname
   in
-  let cwd = Caml.Sys.getcwd () in
+  let cwd = Sys.getcwd () in
   aux cwd
 
 let read_project_config () =
@@ -22,51 +22,60 @@ let read_project_config () =
   | None ->
     Ok None
   | Some project_root ->
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     let project_conf_path = Filename.concat project_root ".spin" in
     let+ dec =
-      Decoder.decode_sexps_file project_conf_path ~f:Dec_project.decode
-      |> Result.map_error
-           ~f:(Spin_error.of_decoder_error ~file:project_conf_path)
+      Decoder.decode_sexps_file project_conf_path Dec_project.decode
+      |> Result.map_error (Spin_error.of_decoder_error ~file:project_conf_path)
     in
     Some { dec; project_root }
 
 let project_generators t =
-  let open Lwt_result.Syntax in
+  let open Result.Syntax in
   let* template_source =
     Template.source_of_dec t.Dec_project.source
-    |> Result.map_error ~f:(fun reason ->
+    |> Result.map_error (fun reason ->
            (* TODO: The error message could be more helpful with the name of the
               template. *)
            Spin_error.generator_error ~msg:reason "")
-    |> Lwt.return
   in
   let+ dec =
     Template.read_source_spin_file template_source ~download_git:false
   in
-  List.map dec.Dec_template.generators ~f:(fun generator ->
+  List.map
+    (fun generator ->
       let open Dec_template.Generator in
       generator.name, generator.description)
+    dec.Dec_template.generators
 
-let run_generator ?context:additionnal_context ~project:t generator =
-  let open Lwt_result.Syntax in
-  let context = Hashtbl.of_alist_exn (module String) t.dec.configs in
+let run_actions ~path actions =
+  let open Result.Syntax in
+  let+ _ =
+    Result.List.fold_left
+      (fun acc el ->
+        let+ action = Template_actions.run ~path el in
+        action :: acc)
+      []
+      actions
+  in
+  ()
+
+let run_generator ?context:additionnal_context ~project:t generator
+    : (unit, Spin_error.t) result
+  =
+  let open Result.Syntax in
+  let context = Hashtbl.of_list t.dec.configs in
   let () =
     match additionnal_context with
     | Some additionnal_context ->
-      Hashtbl.merge_into
-        ~src:additionnal_context
-        ~dst:context
-        ~f:(fun ~key:_ src -> function
-        | Some dst -> Set_to dst | None -> Set_to src)
+      Hashtbl.merge additionnal_context ~into:context
     | None ->
       ()
   in
   let* template_source =
     Template.source_of_dec t.dec.source
-    |> Result.map_error ~f:(fun reason ->
+    |> Result.map_error (fun reason ->
            Spin_error.generator_error ~msg:reason generator)
-    |> Lwt.return
   in
   let* dec =
     Template.read
@@ -76,53 +85,35 @@ let run_generator ?context:additionnal_context ~project:t generator =
       ~ignore_actions:true
       ~ignore_example_commands:true
   in
-  match Hashtbl.find dec.generators generator with
+  match Hashtbl.find_opt dec.generators generator with
   | None ->
-    Lwt.return
-      (Error
-         (Spin_error.generator_error
-            ~msg:
-              (Printf.sprintf
-                 "The generator with the name %S does not exist"
-                 generator)
-            generator))
+    Error
+      (Spin_error.generator_error
+         ~msg:
+           (Printf.sprintf
+              "The generator with the name %S does not exist"
+              generator)
+         generator)
   | Some gen ->
     let* generator = gen () in
     (* Run pre-gen commands *)
-    let* _ =
-      Spin_lwt.result_fold_left
-        generator.pre_gen_actions
-        ~f:(Template_actions.run ~path:t.project_root)
-    in
+    let* _ = run_actions ~path:t.project_root generator.pre_gen_actions in
     (* Generate files *)
-    let* () =
-      Logs_lwt.app (fun m ->
-          m "\n🏗️  Running the generator %a" Pp.pp_blue generator.name)
-      |> Lwt_result.ok
-    in
+    Logs.app (fun m ->
+        m "\n🏗️  Running the generator %a" Pp.pp_blue generator.name);
     let* _ =
       generator.files
-      |> Hashtbl.to_alist
-      |> Spin_lwt.result_fold_left ~f:(fun (path, content) ->
+      |> Hashtbl.to_list
+      |> Result.List.iter_left (fun (path, content) ->
              let path = Filename.concat t.project_root path in
+             (* let dirname = Filename.dirname path in *)
+             (* Sys.mkdir_p dirname; *)
              File_generator.generate path ~context:generator.context ~content)
     in
-    let* () =
-      Logs_lwt.app (fun m -> m "%a" Pp.pp_bright_green "Done!\n")
-      |> Lwt_result.ok
-    in
+    Logs.app (fun m -> m "%a" Pp.pp_bright_green "Done!\n");
     (* Run post-gen commands *)
-    let* _ =
-      Spin_lwt.result_fold_left
-        generator.post_gen_actions
-        ~f:(Template_actions.run ~path:t.project_root)
-    in
+    let+ _ = run_actions ~path:t.project_root generator.post_gen_actions in
     (* Print message *)
-    let+ () =
-      match generator.message with
-      | None ->
-        Lwt.return () |> Lwt_result.ok
-      | Some message ->
-        Logs_lwt.app (fun m -> m "%a" Pp.pp_yellow message) |> Lwt_result.ok
-    in
-    ()
+    Option.iter
+      (fun msg -> Logs.app (fun m -> m "%a" Pp.pp_yellow msg))
+      generator.message

--- a/lib/spin/spin_error.ml
+++ b/lib/spin/spin_error.ml
@@ -56,7 +56,7 @@ let of_decoder_error ~file e =
   failed_to_parse file ~msg
 
 let sexp_of_t t =
-  let open Sexplib0.Sexp in
+  let open Sexplib.Sexp in
   match t with
   | `Missing_env_var e ->
     List [ Atom "Missing_env_var"; Atom e ]
@@ -69,4 +69,4 @@ let sexp_of_t t =
   | `Generator_error (e1, e2) ->
     List [ Atom "Missing_env_var"; Atom e1; Atom e2 ]
 
-let pp fmt t = Sexplib0.Sexp.pp_hum fmt (sexp_of_t t)
+let pp fmt t = Sexplib.Sexp.pp_hum fmt (sexp_of_t t)

--- a/lib/spin/spin_error.mli
+++ b/lib/spin/spin_error.mli
@@ -20,4 +20,4 @@ val generator_error : msg:string -> string -> t
 
 val of_decoder_error : file:string -> Decoder.error -> t
 
-val pp : Formatter.t -> t -> unit [@@ocaml.toplevel_printer]
+val pp : Format.formatter -> t -> unit [@@ocaml.toplevel_printer]

--- a/lib/spin/template.mli
+++ b/lib/spin/template.mli
@@ -20,9 +20,7 @@ type t =
   ; example_commands : example_command list
   ; source : source
   ; generators :
-      ( string
-      , unit -> (Template_generator.t, Spin_error.t) Lwt_result.t )
-      Hashtbl.t
+      (string, unit -> (Template_generator.t, Spin_error.t) Result.t) Hashtbl.t
   }
 
 val source_of_string : string -> source Option.t
@@ -34,12 +32,12 @@ val source_to_dec : source -> Dec_common.Source.t
 val read_source_spin_file
   :  ?download_git:bool
   -> source
-  -> (Dec_template.t, Spin_error.t) Lwt_result.t
+  -> (Dec_template.t, Spin_error.t) Result.t
 
 val read_source_template_files
   :  ?download_git:bool
   -> source
-  -> ((string, string) Hashtbl.t, Spin_error.t) Lwt_result.t
+  -> ((string, string) Hashtbl.t, Spin_error.t) Result.t
 
 val of_dec
   :  ?use_defaults:bool
@@ -51,7 +49,7 @@ val of_dec
   -> source:source
   -> context:(string, string) Hashtbl.t
   -> Dec_template.t
-  -> (t, Spin_error.t) Lwt_result.t
+  -> (t, Spin_error.t) Result.t
 
 val read
   :  ?use_defaults:bool
@@ -61,6 +59,6 @@ val read
   -> ?ignore_generators:bool
   -> ?context:(string, string) Hashtbl.t
   -> source
-  -> (t, Spin_error.t) Lwt_result.t
+  -> (t, Spin_error.t) Result.t
 
-val generate : path:string -> t -> (unit, Spin_error.t) Lwt_result.t
+val generate : path:string -> t -> (unit, Spin_error.t) Result.t

--- a/lib/spin/template_actions.mli
+++ b/lib/spin/template_actions.mli
@@ -12,14 +12,11 @@ type t =
   ; actions : action list
   }
 
-val of_dec
-  :  context:(string, string) Hashtbl.t
-  -> Dec_template.Actions.t
-  -> t Lwt.t
+val of_dec : context:(string, string) Hashtbl.t -> Dec_template.Actions.t -> t
 
 val of_decs_with_condition
   :  context:(string, string) Hashtbl.t
   -> Dec_template.Actions.t list
-  -> (t list, Spin_error.t) Lwt_result.t
+  -> (t list, Spin_error.t) Result.t
 
-val run : path:string -> t -> (unit, Spin_error.t) Lwt_result.t
+val run : path:string -> t -> (unit, Spin_error.t) Result.t

--- a/lib/spin/template_configuration.ml
+++ b/lib/spin/template_configuration.ml
@@ -3,14 +3,13 @@ open Dec_template
 exception Failed_rule_eval of Spin_error.t
 
 let validate_of_rule ~context ~config_name (rule : Configuration.rule) =
-  let open Lwt.Syntax in
   let context_with_config = Hashtbl.copy context in
-  fun v ->
-    Hashtbl.set context_with_config ~key:config_name ~data:v;
-    let* result =
+  fun (v : string) ->
+    Hashtbl.add context_with_config config_name v;
+    let result =
       Template_expr.to_result
+        Template_expr.to_bool
         rule.expr
-        ~f:Template_expr.to_bool
         ~context:context_with_config
     in
     match result with
@@ -18,99 +17,102 @@ let validate_of_rule ~context ~config_name (rule : Configuration.rule) =
       raise (Failed_rule_eval e)
     | Ok result ->
       if result then
-        Lwt.return (Ok v)
+        Ok v
       else
-        let+ error_message = Template_expr.eval rule.message ~context in
+        let error_message = Template_expr.eval rule.message ~context in
         Error error_message
 
 let prompt_config ?(use_defaults = false) ~context (config : Configuration.t) =
-  let open Lwt_result.Syntax in
+  let open Result.Syntax in
   let* default =
     match config.default with
     | None ->
-      Lwt.return (Ok None)
+      Ok None
     | Some default ->
       let+ result =
-        Template_expr.to_result default ~f:Template_expr.eval ~context
+        Template_expr.to_result Template_expr.eval default ~context
       in
       Some result
   in
   let validate =
     List.fold_left
-      config.rules
-      ~init:(fun v -> Lwt_result.return v)
-      ~f:(fun acc rule v ->
+      (fun acc rule v ->
         let f = validate_of_rule ~context ~config_name:config.name rule in
-        Lwt_result.bind (acc v) f)
+        Result.bind (acc v) f)
+      (fun v -> Result.ok v)
+      config.rules
   in
   match use_defaults, config.prompt, default with
   | true, _, Some default ->
-    Lwt_result.return (Some default)
+    Result.ok (Some default)
   | _, Some (Configuration.Input input_t), _ ->
-    let+ v =
-      Inquire.input input_t.message ?default ~validate |> Lwt_result.ok
-    in
+    let+ v = Inquire.input input_t.message ?default ~validate |> Result.ok in
     Some v
   | _, Some (Configuration.Select select_t), _ ->
+    let default_v =
+      (* Find the index of the default value if provided. *)
+      Option.map
+        (fun default -> List.index (String.equal default) select_t.values)
+        default
+    in
     let+ v =
-      Inquire.select select_t.message ~options:select_t.values ?default
-      |> Lwt_result.ok
+      Inquire.select
+        select_t.message
+        ~options:select_t.values
+        ?default:default_v
+      |> Result.ok
     in
     Some v
   | _, Some (Configuration.Confirm confirm_t), _ ->
     let* default =
       match default with
       | None ->
-        Lwt_result.return None
+        Result.ok None
       | Some default ->
         let+ result =
           Template_expr.to_result
+            Template_expr.to_bool
             (Expr.String default)
-            ~f:Template_expr.to_bool
             ~context
         in
         Some result
     in
-    let+ v = Inquire.confirm confirm_t.message ?default |> Lwt_result.ok in
+    let+ v = Inquire.confirm confirm_t.message ?default |> Result.ok in
     Some (Bool.to_string v)
   | _, None, _ ->
-    Lwt.return (Ok default)
+    Ok default
 
 let populate_context
     ?(use_defaults = false)
     ~context
     (configurations : Dec_template.Configuration.t list)
   =
-  let open Lwt_result.Syntax in
-  List.fold_left
-    configurations
-    ~init:(Lwt_result.return ())
-    ~f:(fun acc config ->
-      let* () = acc in
+  let open Result.Syntax in
+  Result.List.fold_left
+    (fun _ (config : Configuration.t) ->
       if Hashtbl.mem context config.name then
-        Lwt_result.return ()
+        Result.ok ()
       else
         let env_var_name =
-          Printf.sprintf "SPIN_%s" (String.uppercase config.name)
+          Printf.sprintf "SPIN_%s" (String.uppercase_ascii config.name)
         in
-        match Sys.getenv env_var_name with
+        match Sys.getenv_opt env_var_name with
         | Some data ->
-          let _ = Hashtbl.add context ~key:config.name ~data in
-          Lwt_result.return ()
+          Hashtbl.add context config.name data;
+          Result.ok ()
         | None ->
           let+ data_opt =
-            let* result = prompt_config config ~context ~use_defaults in
-            Lwt.catch
-              (fun () -> Lwt_result.return result)
-              (function
-                | Failed_rule_eval e ->
-                  Lwt.return (Error e)
-                | exn ->
-                  Lwt.fail exn)
+            try prompt_config config ~context ~use_defaults with
+            | Failed_rule_eval e ->
+              Error e
+            | exn ->
+              raise exn
           in
           (match data_opt with
           | Some data ->
-            let _ = Hashtbl.add context ~key:config.name ~data in
+            Hashtbl.add context config.name data;
             ()
           | None ->
             ()))
+    ()
+    configurations

--- a/lib/spin/template_expr.ml
+++ b/lib/spin/template_expr.ml
@@ -4,9 +4,9 @@ exception Invalid_expr of string
 
 let rec eval ~context = function
   | Expr.Var name ->
-    (match Hashtbl.find context name with
+    (match Hashtbl.find_opt context name with
     | Some var ->
-      Lwt.return var
+      var
     | None ->
       raise
         (Invalid_expr
@@ -14,116 +14,96 @@ let rec eval ~context = function
   | Expr.Function fn ->
     eval_fn fn ~context
   | Expr.String s ->
-    Lwt.return s
+    s
 
 and eval_fn ~context =
-  let open Lwt.Syntax in
   let eval = eval ~context in
   let to_bool = to_bool ~context in
   function
   | Expr.If (e1, e2, e3) ->
-    let* e1 = to_bool e1 in
+    let e1 = to_bool e1 in
     if e1 then eval e2 else eval e3
   | Expr.And (e1, e2) ->
-    let* e1 = to_bool e1 in
-    let+ e2 = to_bool e2 in
+    let e1 = to_bool e1 in
+    let e2 = to_bool e2 in
     (e1 && e2) |> Bool.to_string
   | Expr.Or (e1, e2) ->
-    let* e1 = to_bool e1 in
-    let+ e2 = to_bool e2 in
+    let e1 = to_bool e1 in
+    let e2 = to_bool e2 in
     (e1 || e2) |> Bool.to_string
   | Expr.Eq (e1, e2) ->
-    let* e1 = eval e1 in
-    let+ e2 = eval e2 in
+    let e1 = eval e1 in
+    let e2 = eval e2 in
     String.equal e1 e2 |> Bool.to_string
   | Expr.Neq (e1, e2) ->
-    let* e1 = eval e1 in
-    let+ e2 = eval e2 in
+    let e1 = eval e1 in
+    let e2 = eval e2 in
     (not (String.equal e1 e2)) |> Bool.to_string
   | Expr.Not e ->
-    let+ e = to_bool e in
+    let e = to_bool e in
     (not e) |> Bool.to_string
   | Expr.Slugify e ->
-    let+ e = eval e in
+    let e = eval e in
     Helpers.slugify e
   | Expr.Upper e ->
-    let+ e = eval e in
-    String.uppercase e
+    let e = eval e in
+    String.uppercase_ascii e
   | Expr.Lower e ->
-    let+ e = eval e in
-    String.lowercase e
+    let e = eval e in
+    String.lowercase_ascii e
   | Expr.Snake_case e ->
-    let+ e = eval e in
+    let e = eval e in
     Helpers.snake_case e
   | Expr.Camel_case e ->
-    let+ e = eval e in
+    let e = eval e in
     Helpers.camel_case e
   | Expr.Trim e ->
-    let+ e = eval e in
-    String.strip e
+    let e = eval e in
+    String.trim e
   | Expr.First_char e ->
-    let+ e = eval e in
+    let e = eval e in
     String.prefix e 1
   | Expr.Last_char e ->
-    let+ e = eval e in
+    let e = eval e in
     String.suffix e 1
   | Expr.Run (cmd, args) ->
-    let* cmd = eval cmd in
-    let* args = Spin_lwt.fold_left args ~f:eval in
-    let+ p_out = Spin_lwt.exec cmd args in
-    (match p_out.status with WEXITED 0 -> "false" | _ -> "true")
+    let cmd = eval cmd in
+    let args = List.fold_left (fun acc arg -> eval arg :: acc) [] args in
+    (match Spawn.exec cmd (List.rev args) with Ok () -> "false" | _ -> "true")
   | Expr.Concat l ->
-    let+ l = Spin_lwt.fold_left l ~f:eval in
-    String.concat l
+    let l = List.fold_left (fun acc arg -> eval arg :: acc) [] l in
+    String.concat "" (List.rev l)
 
 and to_bool ~context expr =
-  let open Lwt.Syntax in
-  let* e = eval expr ~context in
-  Lwt.catch
-    (fun () -> Bool.of_string e |> Lwt.return)
-    (function
-      | Invalid_expr _ as e ->
-        raise e
-      | _ ->
-        Lwt.fail
-          (Invalid_expr "The expression cannot be evaluated to a boolean"))
+  let e = eval expr ~context in
+  try bool_of_string e with
+  | Invalid_expr _ as e ->
+    raise e
+  | _ ->
+    raise (Invalid_expr "The expression cannot be evaluated to a boolean")
 
-let to_result ~context ~f expr =
-  Lwt.catch
-    (fun () -> f ~context expr |> Lwt_result.ok)
-    (function
-      | Invalid_expr reason ->
-        Error (Spin_error.failed_to_generate reason) |> Lwt.return
-      | _ ->
-        Error
-          (Spin_error.failed_to_generate
-             "Failed to evaluate an expression for unknown reason")
-        |> Lwt.return)
+let to_result ~context f expr =
+  try f ~context expr |> Result.ok with
+  | Invalid_expr reason ->
+    Error (Spin_error.failed_to_generate reason)
+  | _ ->
+    Error
+      (Spin_error.failed_to_generate
+         "Failed to evaluate an expression for unknown reason")
 
-let filter_map ~context ~condition ~f l =
-  let open Lwt_result.Syntax in
-  List.fold_right l ~init:(Lwt_result.return []) ~f:(fun el acc ->
+let filter_map ~context ~condition f l =
+  let open Result.Syntax in
+  List.fold_right
+    (fun el acc ->
       let* acc = acc in
       match condition el with
       | None ->
-        Lwt_result.return (f el :: acc)
+        Result.ok (f el :: acc)
       | Some expr ->
-        let+ result = to_result expr ~f:to_bool ~context in
+        let+ result = to_result to_bool expr ~context in
         if result then
           f el :: acc
         else
           acc)
-
-let lwt_filter_map ~context ~condition ~f l =
-  let open Lwt_result.Syntax in
-  List.fold_right l ~init:(Lwt_result.return []) ~f:(fun el acc ->
-      let* acc = acc in
-      match condition el with
-      | None ->
-        Lwt.bind (f el) (fun result -> Lwt_result.return (result :: acc))
-      | Some condition ->
-        let* result = to_result condition ~f:to_bool ~context in
-        if result then
-          Lwt.bind (f el) (fun result -> Lwt_result.return (result :: acc))
-        else
-          Lwt_result.return acc)
+    l
+    (Result.ok [])

--- a/lib/spin/template_sources/git_template.ml
+++ b/lib/spin/template_sources/git_template.ml
@@ -4,7 +4,7 @@ let repo_regex =
 let cache_dir_of_repo repo =
   let regexp = Str.regexp repo_regex in
   if Str.string_match regexp repo 0 then
-    let open Result.Let_syntax in
+    let open Result.Syntax in
     let repo_name = Str.matched_group 7 repo in
     let+ cache_dir = Config.spin_cache_dir in
     Filename.of_parts [ cache_dir; repo_name ]
@@ -15,49 +15,49 @@ let cache_dir_of_repo repo =
          ~msg:"The Git repo URI could not be parsed.")
 
 let git_clone ~destination repo =
-  let open Lwt_result.Syntax in
+  let open Result.Syntax in
   let* () =
-    Logs_lwt.app (fun m ->
+    Logs.app (fun m ->
         m "📡  Downloading %a to %s" Pp.pp_blue repo destination)
-    |> Lwt_result.ok
+    |> Result.ok
   in
   let* () =
-    Logs_lwt.debug (fun m -> m "Cloning %S to %S" repo destination)
-    |> Lwt_result.ok
+    Logs.debug (fun m -> m "Cloning %S to %S" repo destination) |> Result.ok
   in
   let* () =
-    Spin_lwt.exec_with_logs "git" [ "clone"; repo; destination ]
-    |> Lwt_result.map_err (fun _ ->
-           Spin_error.invalid_template
-             repo
-             ~msg:"The repository could not be downloaded.")
+    Spawn.exec "git" [ "clone"; repo; destination ]
+    |> Result.map_error (fun err ->
+           let msg =
+             Printf.sprintf "The repository could not be downloaded: %s" err
+           in
+           Spin_error.invalid_template repo ~msg)
   in
-  Logs_lwt.app (fun m -> m "%a" Pp.pp_bright_green "Done!\n") |> Lwt_result.ok
+  Logs.app (fun m -> m "%a" Pp.pp_bright_green "Done!\n") |> Result.ok
 
 let donwload_git_repo repo =
-  let open Lwt_result.Syntax in
-  let* cache_dir = cache_dir_of_repo repo |> Lwt.return in
+  let open Result.Syntax in
+  let* cache_dir = cache_dir_of_repo repo in
   let+ () =
-    if Caml.Sys.file_exists cache_dir && Caml.Sys.is_directory cache_dir then
+    if Sys.file_exists cache_dir && Sys.is_directory cache_dir then
       let* () =
-        Logs_lwt.app (fun m ->
+        Logs.app (fun m ->
             m "The repository %a has already been downloaded." Pp.pp_blue repo)
-        |> Lwt_result.ok
+        |> Result.ok
       in
       let* refetch =
         Inquire.confirm "Do you want to download it again?" ~default:true
-        |> Lwt_result.ok
+        |> Result.ok
       in
       if refetch then (
         let* () =
-          Logs_lwt.debug (fun m -> m "Removing %S" cache_dir) |> Lwt_result.ok
+          Logs.debug (fun m -> m "Removing %S" cache_dir) |> Result.ok
         in
-        Spin_unix.rm_p cache_dir;
+        Sys.rm_p cache_dir;
         git_clone repo ~destination:cache_dir)
       else
-        Lwt_result.return ()
+        Result.ok ()
     else (
-      Spin_unix.mkdir_p cache_dir;
+      Sys.mkdir_p cache_dir;
       git_clone repo ~destination:cache_dir)
   in
   cache_dir

--- a/lib/spin/template_sources/local_template.ml
+++ b/lib/spin/template_sources/local_template.ml
@@ -1,35 +1,32 @@
-let read_file path =
-  Lwt_io.with_file ~mode:Input path (fun ic -> Lwt_io.read ic)
-
 let read_spin_file path =
-  let open Lwt_result.Syntax in
+  let open Result.Syntax in
   let spin_file_path = Filename.concat path "spin" in
-  let* file_exists = Lwt_result.ok @@ Lwt_unix.file_exists spin_file_path in
+  let* file_exists = Result.ok @@ Sys.file_exists spin_file_path in
   let* content =
     if file_exists then
-      Lwt_result.ok @@ read_file spin_file_path
+      Result.ok @@ Sys.read_file spin_file_path
     else
-      Lwt.return
-        (Error
-           (Spin_error.invalid_template
-              path
-              ~msg:"The directory does not contain a \"spin\" file."))
+      Error
+        (Spin_error.invalid_template
+           path
+           ~msg:"The directory does not contain a \"spin\" file.")
   in
-  match Decoder.decode_sexps_string content ~f:Dec_template.decode with
+  match Decoder.decode_sexps_string content Dec_template.decode with
   | Ok spin_file ->
-    Lwt.return (Ok spin_file)
+    Ok spin_file
   | Error e ->
     let msg = Decoder.string_of_error e in
-    Error (Spin_error.failed_to_parse "spin" ~msg) |> Lwt.return
+    Error (Spin_error.failed_to_parse "spin" ~msg)
 
 let files_with_content root_path =
-  let open Lwt.Syntax in
-  let dir_files = Spin_sys.ls_dir root_path in
+  let dir_files = Sys.ls_dir root_path in
   let root_path = Fpath.v root_path in
-  List.fold_left dir_files ~init:(Lwt.return []) ~f:(fun acc path ->
-      let* acc = acc in
-      let+ content = read_file path in
+  List.fold_left
+    (fun acc path ->
+      let content = Sys.read_file path in
       let fpath = Fpath.v path in
       let fpath = Fpath.rem_prefix root_path fpath in
-      let path = Fpath.to_string (Option.value_exn fpath) in
+      let path = Fpath.to_string (Option.get fpath) in
       (path, content) :: acc)
+    []
+    dir_files

--- a/lib/spin/template_sources/local_template.mli
+++ b/lib/spin/template_sources/local_template.mli
@@ -1,3 +1,3 @@
-val read_spin_file : string -> (Dec_template.t, Spin_error.t) Lwt_result.t
+val read_spin_file : string -> (Dec_template.t, Spin_error.t) Result.t
 
-val files_with_content : string -> (string * string) list Lwt.t
+val files_with_content : string -> (string * string) list

--- a/lib/spin/template_sources/official_template.ml
+++ b/lib/spin/template_sources/official_template.ml
@@ -8,7 +8,7 @@ type doc =
 let read_spin_file (module T : Spin_template.Template) =
   match T.read "spin" with
   | Some content ->
-    (match Decoder.decode_sexps_string content ~f:Dec_template.decode with
+    (match Decoder.decode_sexps_string content Dec_template.decode with
     | Ok spin_file ->
       Ok spin_file
     | Error e ->
@@ -31,8 +31,13 @@ let all_doc () =
   aux [] all
 
 let files_with_content (module T : Spin_template.Template) =
-  List.map T.file_list ~f:(fun path ->
-      let content = Option.value_exn (T.read path) in
+  List.map
+    (fun path ->
+      let content = Option.get (T.read path) in
       path, content)
+    T.file_list
 
-let of_name s = List.find all ~f:(fun (module T) -> String.equal s T.name)
+let of_name s =
+  List.find_opt
+    (fun (module T : Spin_template.Template) -> String.equal s T.name)
+    all

--- a/lib/spin/user_config.mli
+++ b/lib/spin/user_config.mli
@@ -11,6 +11,6 @@ val read : ?path:string -> unit -> (t option, Spin_error.t) Result.t
 
 val save : ?path:string -> t -> (unit, Spin_error.t) Result.t
 
-val prompt : ?default:t -> unit -> t Lwt.t
+val prompt : ?default:t -> unit -> t
 
 val to_context : t -> (string, string) Hashtbl.t

--- a/lib/spin_std/dune
+++ b/lib/spin_std/dune
@@ -1,4 +1,4 @@
 (library
  (name spin_std)
  (public_name spin.std)
- (libraries base unix lwt lwt.unix logs logs.lwt))
+ (libraries unix spawn))

--- a/lib/spin_std/filename.ml
+++ b/lib/spin_std/filename.ml
@@ -1,0 +1,33 @@
+open Stdlib.Filename
+
+let check_suffix = check_suffix
+
+let chop_extension = chop_extension
+
+let chop_suffix = chop_suffix
+
+let current_dir_name = current_dir_name
+
+let is_implicit = is_implicit
+
+let is_relative = is_relative
+
+let parent_dir_name = parent_dir_name
+
+let dir_sep = dir_sep
+
+let quote = quote
+
+let temp_dir_name = get_temp_dir_name ()
+
+let dirname = dirname
+
+let basename = basename
+
+let of_parts = function
+  | [] ->
+    failwith "Filename.of_parts: empty parts list"
+  | root :: rest ->
+    List.fold_left concat root rest
+
+let concat = concat

--- a/lib/spin_std/filename.mli
+++ b/lib/spin_std/filename.mli
@@ -1,0 +1,27 @@
+val check_suffix : string -> string -> bool
+
+val chop_extension : string -> string
+
+val chop_suffix : string -> string -> string
+
+val current_dir_name : string
+
+val is_implicit : string -> bool
+
+val is_relative : string -> bool
+
+val parent_dir_name : string
+
+val dir_sep : string
+
+val quote : string -> string
+
+val temp_dir_name : string
+
+val dirname : string -> string
+
+val basename : string -> string
+
+val of_parts : string list -> string
+
+val concat : string -> string -> string

--- a/lib/spin_std/hashtbl.ml
+++ b/lib/spin_std/hashtbl.ml
@@ -1,0 +1,8 @@
+include Stdlib.Hashtbl
+
+let to_list t = to_seq t |> List.of_seq
+
+let of_list l = of_seq (List.to_seq l)
+
+let merge ~into:tab1 tab2 =
+  fold (fun key elt () -> replace tab1 key elt) tab2 ()

--- a/lib/spin_std/list.ml
+++ b/lib/spin_std/list.ml
@@ -1,0 +1,13 @@
+include Stdlib.List
+
+let index f t =
+  let rec aux acc = function
+    | [] ->
+      raise Not_found
+    | el :: rest ->
+      if f el then
+        acc
+      else
+        aux (acc + 1) rest
+  in
+  aux 0 t

--- a/lib/spin_std/result.ml
+++ b/lib/spin_std/result.ml
@@ -1,0 +1,71 @@
+include Stdlib.Result
+
+let both a b =
+  match a with
+  | Error e ->
+    Error e
+  | Ok a ->
+    (match b with Error e -> Error e | Ok b -> Ok (a, b))
+
+module Syntax = struct
+  let ( >>= ) t f = bind t f
+
+  let ( >>| ) t f = map f t
+
+  let ( let* ) = ( >>= )
+
+  let ( let+ ) = ( >>| )
+
+  let ( and+ ) = both
+end
+
+open Syntax
+
+module List = struct
+  let map f t =
+    let rec loop acc = function
+      | [] ->
+        Ok (List.rev acc)
+      | x :: xs ->
+        f x >>= fun x -> loop (x :: acc) xs
+    in
+    loop [] t
+
+  let all =
+    let rec loop acc = function
+      | [] ->
+        Ok (List.rev acc)
+      | t :: l ->
+        t >>= fun x -> loop (x :: acc) l
+    in
+    fun l -> loop [] l
+
+  let concat_map =
+    let rec loop f acc = function
+      | [] ->
+        Ok (List.rev acc)
+      | x :: l ->
+        f x >>= fun y -> loop f (List.rev_append y acc) l
+    in
+    fun l f -> loop f [] l
+
+  let rec iter f t =
+    match t with [] -> Ok () | x :: xs -> f x >>= fun () -> iter f xs
+
+  let rec fold_left f init t =
+    match t with
+    | [] ->
+      Ok init
+    | x :: xs ->
+      f init x >>= fun init -> fold_left f init xs
+
+  let rec iter_left f t =
+    match t with [] -> Ok () | x :: xs -> f x >>= fun () -> iter_left f xs
+
+  let filter_map t f =
+    fold_left
+      (fun acc x -> f x >>| function None -> acc | Some y -> y :: acc)
+      []
+      t
+    >>| List.rev
+end

--- a/lib/spin_std/spin_std.ml
+++ b/lib/spin_std/spin_std.ml
@@ -1,272 +1,45 @@
-include Base
-
-module Result = struct
-  include Base.Result
-
-  module Let_syntax = struct
-    let ( let+ ) = ( >>| )
-
-    let ( let* ) = ( >>= )
-
-    let ( and+ ) = Let_syntax.Let_syntax.both
-  end
-
-  let fold_left ~f l =
-    List.fold_left l ~init:(Ok ()) ~f:(fun acc el ->
-        bind acc ~f:(fun () -> f el))
-
-  let fold_right ~f l =
-    List.fold_right l ~init:(Ok ()) ~f:(fun el acc ->
-        bind acc ~f:(fun () -> f el))
-end
-
-(* Follows Core's API but stripped everything that is POSIX only *)
-module Filename = struct
-  include struct
-    open Caml.Filename
-
-    let check_suffix = check_suffix
-
-    let chop_extension = chop_extension
-
-    let chop_suffix = chop_suffix
-
-    let current_dir_name = current_dir_name
-
-    let is_implicit = is_implicit
-
-    let is_relative = is_relative
-
-    let parent_dir_name = parent_dir_name
-
-    let dir_sep = dir_sep
-
-    let quote = quote
-
-    let temp_dir_name = get_temp_dir_name ()
-
-    let dirname = dirname
-
-    let basename = basename
-  end
-
-  let of_parts = function
-    | [] ->
-      failwith "Filename.of_parts: empty parts list"
-    | root :: rest ->
-      List.fold rest ~init:root ~f:Caml.Filename.concat
-
-  let concat = Caml.Filename.concat
-end
-
 module Glob = Glob
+module Hashtbl = Hashtbl
+module List = List
+module Result = Result
+module String = String
+module Filename = Filename
+module Sys = Sys
 
-module Spin_unix = struct
-  open Unix
+module Spawn = struct
+  include Spawn
 
-  let mkdir ?(perm = 0o777) dirname = mkdir dirname perm
-
-  let rec mkdir_p ?perm dir =
-    let mkdir_idempotent ?perm dir =
-      match mkdir ?perm dir with
-      | () ->
-        ()
-      (* [mkdir] on MacOSX returns [EISDIR] instead of [EEXIST] if the directory
-         already exists. *)
-      | exception Unix_error ((EEXIST | EISDIR), _, _) ->
-        ()
-    in
-    match mkdir_idempotent ?perm dir with
-    | () ->
-      ()
-    | exception (Unix_error (ENOENT, _, _) as exn) ->
-      let parent = Filename.dirname dir in
-      if String.equal parent dir then
-        raise exn
-      else (
-        mkdir_p ?perm parent;
-        mkdir_idempotent ?perm dir)
-
-  let rec rm_p path =
-    match Caml.Sys.is_directory path with
-    | true ->
-      Caml.Sys.readdir path
-      |> Array.iter ~f:(fun name -> rm_p (Filename.concat path name));
-      Unix.rmdir path
-    | false ->
-      Caml.Sys.remove path
-end
-
-module Spin_lwt = struct
-  include Lwt
-
-  let fold_left ~f l =
-    let open Syntax in
-    let+ l =
-      List.fold_left l ~init:(Lwt.return []) ~f:(fun acc el ->
-          let* acc = acc in
-          let+ result = f el in
-          result :: acc)
-    in
-    List.rev l
-
-  let fold_right ~f l =
-    let open Syntax in
-    let+ l =
-      List.fold_right l ~init:(Lwt.return []) ~f:(fun el acc ->
-          let* acc = acc in
-          let+ result = f el in
-          result :: acc)
-    in
-    List.rev l
-
-  let result_fold_left ~f l =
-    let open Lwt_result.Syntax in
-    let+ l =
-      List.fold_left l ~init:(Lwt_result.return []) ~f:(fun acc el ->
-          let* acc = acc in
-          let+ result = f el in
-          result :: acc)
-    in
-    List.rev l
-
-  let result_fold_right ~f l =
-    let open Lwt_result.Syntax in
-    let+ l =
-      List.fold_right l ~init:(Lwt_result.return []) ~f:(fun el acc ->
-          let* acc = acc in
-          let+ result = f el in
-          result :: acc)
-    in
-    List.rev l
-
-  type command_result =
-    { stdout : string list
-    ; stderr : string list
-    ; status : Unix.process_status
-    }
-
-  let command_result_of_process process =
-    let open Lwt.Syntax in
-    let* status = process#status in
-    let* stdout = Lwt_io.read_lines process#stdout |> Lwt_stream.to_list in
-    let+ stderr = Lwt_io.read_lines process#stderr |> Lwt_stream.to_list in
-    { stdout; stderr; status }
-
-  let prepare_args cmd args = "", Array.of_list (cmd :: args)
-
-  let exec cmd args =
-    Lwt_process.with_process_full
-      (prepare_args cmd args)
-      command_result_of_process
-
-  let exec_with_logs cmd args =
-    let open Lwt.Syntax in
-    let* p_output = exec cmd args in
-    let* _ =
-      fold_left p_output.stdout ~f:(fun line ->
-          Logs_lwt.debug (fun m -> m "stdout of %s: %s" cmd line))
-    in
-    match p_output.status with
-    | WEXITED 0 ->
-      let+ _ =
-        fold_left p_output.stderr ~f:(fun line ->
-            Logs_lwt.debug (fun m -> m "stderr of %s: %s" cmd line))
-      in
-      Ok ()
-    | _ ->
-      let+ _ =
-        fold_left p_output.stderr ~f:(fun line ->
-            Logs_lwt.err (fun m -> m "stderr of %s: %s" cmd line))
-      in
-      Error
-        (Caml.Format.asprintf
-           "The command %s did not run successfully: %a"
-           cmd
-           (Caml.Format.pp_print_list Caml.Format.pp_print_string)
-           p_output.stderr)
-
-  let exec_with_stdout cmd args =
-    let open Lwt.Syntax in
-    let* p_output = exec cmd args in
-    let* _ =
-      fold_left p_output.stdout ~f:(fun line ->
-          Logs_lwt.debug (fun m -> m "stdout of %s: %s" cmd line))
-    in
-    match p_output.status with
-    | WEXITED 0 ->
-      let+ _ =
-        fold_left p_output.stderr ~f:(fun line ->
-            Logs_lwt.debug (fun m -> m "stderr of %s: %s" cmd line))
-      in
-      let stdout = String.concat ~sep:"\n" p_output.stdout in
-      Ok stdout
-    | _ ->
-      let+ _ =
-        fold_left p_output.stderr ~f:(fun line ->
-            Logs_lwt.err (fun m -> m "stderr of %s: %s" cmd line))
-      in
-      Error
-        (Caml.Format.asprintf
-           "The command %s did not run successfully: %a"
-           cmd
-           (Caml.Format.pp_print_list Caml.Format.pp_print_string)
-           p_output.stderr)
-
-  let with_chdir ~dir t =
-    let open Lwt.Syntax in
-    let old_cwd = Caml.Sys.getcwd () in
-    let* () = Lwt_unix.chdir dir in
-    Lwt.finalize t (fun () -> Lwt_unix.chdir old_cwd)
-end
-
-module Spin_sys = struct
-  include Sys
-
-  let rand_digits () =
-    let rand = Random.State.(bits (make_self_init ()) land 0xFFFFFF) in
-    Printf.sprintf "%06x" rand
-
-  let mk_temp_dir ?(mode = 0o700) ?dir pat =
-    let dir =
-      match dir with Some d -> d | None -> Caml.Filename.get_temp_dir_name ()
-    in
-    let raise_err msg = raise (Sys_error msg) in
-    let rec loop count =
-      if count < 0 then
-        raise_err "mk_temp_dir: too many failing attemps"
-      else
-        let dir = Printf.sprintf "%s/%s%s" dir pat (rand_digits ()) in
-        try
-          Unix.mkdir dir mode;
-          dir
-        with
-        | Unix.Unix_error (Unix.EEXIST, _, _) ->
-          loop (count - 1)
-        | Unix.Unix_error (Unix.EINTR, _, _) ->
-          loop count
-        | Unix.Unix_error (e, _, _) ->
-          raise_err ("mk_temp_dir: " ^ Unix.error_message e)
-    in
-    loop 1000
-
-  let ls_dir ?(recursive = true) directory =
-    if recursive then
-      let rec loop result = function
-        | f :: fs when Caml.Sys.is_directory f ->
-          Caml.Sys.readdir f
-          |> Array.to_list
-          |> List.map ~f:(Caml.Filename.concat f)
-          |> List.append fs
-          |> loop result
-        | f :: fs ->
-          loop (f :: result) fs
-        | [] ->
-          result
-      in
-      loop [] [ directory ] |> List.rev
+  let resolve_in_path prog =
+    (* Do not try to resolve in the path if the program is something like
+     * ./this.exe *)
+    if String.split_on_char '/' prog |> List.length <> 1 then
+      Some prog
     else
-      Caml.Sys.readdir directory
-      |> Array.to_list
-      |> List.map ~f:(Caml.Filename.concat directory)
+      let paths = Sys.getenv "PATH" |> String.split_on_char ':' in
+      List.map (fun d -> Filename.concat d prog) paths
+      |> List.find_opt Sys.file_exists
+
+  let resolve_in_path_exn prog =
+    match resolve_in_path prog with
+    | None ->
+      failwith (Printf.sprintf "no program in path %s" prog)
+    | Some prog ->
+      prog
+
+  let spawn ?env ?cwd ?stdin ?stdout ?stderr prog argv =
+    let prog = resolve_in_path_exn prog in
+    let argv = prog :: argv in
+    spawn ~prog ~argv ?env ?cwd ?stdin ?stdout ?stderr ()
+
+  let exec ?env ?cwd ?stdin ?stdout ?stderr prog argv =
+    let pid = spawn ?env ?cwd ?stdin ?stdout ?stderr prog argv in
+    match snd (Unix.waitpid [] pid) with
+    | WEXITED 0 ->
+      Ok ()
+    | WEXITED n ->
+      Error (Printf.sprintf "exited with code %d" n)
+    | WSIGNALED n ->
+      Error (Printf.sprintf "exited with signal %d" n)
+    | WSTOPPED n ->
+      Error (Printf.sprintf "stopped with code %d" n)
 end

--- a/lib/spin_std/string.ml
+++ b/lib/spin_std/string.ml
@@ -1,0 +1,16 @@
+include Stdlib.String
+
+let lsplit2_exn on s =
+  let i = index s on in
+  sub s 0 i, sub s (i + 1) (length s - i - 1)
+
+let lsplit2 on s = try Some (lsplit2_exn s on) with Not_found -> None
+
+let prefix s len = try sub s 0 len with Invalid_argument _ -> ""
+
+let suffix s len =
+  try sub s (length s - len) len with Invalid_argument _ -> ""
+
+let drop_prefix s len = sub s len (length s - len)
+
+let drop_suffix s len = sub s 0 (length s - len)

--- a/lib/spin_std/sys.ml
+++ b/lib/spin_std/sys.ml
@@ -1,0 +1,107 @@
+include Stdlib.Sys
+
+let mkdir ?(perm = 0o755) dirname = Unix.mkdir dirname perm
+
+let rec mkdir_p ?perm dir =
+  match dir with
+  | "." | ".." ->
+    ()
+  | _ ->
+    let mkdir_idempotent ?(perm = 0o755) dir =
+      match Unix.mkdir dir perm with
+      | () ->
+        ()
+      (* [mkdir] on MacOSX returns [EISDIR] instead of [EEXIST] if the directory
+         already exists. *)
+      | (exception Unix.Unix_error ((EEXIST | EISDIR), _, _))
+      | (exception Sys_error _) ->
+        ()
+    in
+    (match mkdir_idempotent ?perm dir with
+    | () ->
+      ()
+    | exception (Unix.Unix_error (ENOENT, _, _) as exn) ->
+      let parent = Filename.dirname dir in
+      if String.equal parent dir then
+        raise exn
+      else (
+        mkdir_p ?perm parent;
+        mkdir_idempotent ?perm dir))
+
+let rec rm_p path =
+  match is_directory path with
+  | true ->
+    readdir path |> Array.iter (fun name -> rm_p (Filename.concat path name));
+    Unix.rmdir path
+  | false ->
+    remove path
+
+let rand_digits () =
+  let rand = Random.State.(bits (make_self_init ()) land 0xFFFFFF) in
+  Printf.sprintf "%06x" rand
+
+let mk_temp_dir ?(mode = 0o700) ?dir pat =
+  let dir = match dir with Some d -> d | None -> Filename.temp_dir_name in
+  let raise_err msg = raise (Sys_error msg) in
+  let rec loop count =
+    if count < 0 then
+      raise_err "mk_temp_dir: too many failing attemps"
+    else
+      let dir = Printf.sprintf "%s/%s%s" dir pat (rand_digits ()) in
+      try
+        mkdir dir ~perm:mode;
+        dir
+      with
+      | Unix.Unix_error (Unix.EEXIST, _, _) ->
+        loop (count - 1)
+      | Unix.Unix_error (Unix.EINTR, _, _) ->
+        loop count
+      | Unix.Unix_error (e, _, _) ->
+        raise_err ("mk_temp_dir: " ^ Unix.error_message e)
+  in
+  loop 1000
+
+let ls_dir ?(recursive = true) directory =
+  if recursive then
+    let rec loop result = function
+      | f :: fs when is_directory f ->
+        readdir f
+        |> Array.to_list
+        |> List.map (Filename.concat f)
+        |> List.append fs
+        |> loop result
+      | f :: fs ->
+        loop (f :: result) fs
+      | [] ->
+        result
+    in
+    loop [] [ directory ] |> List.rev
+  else
+    readdir directory |> Array.to_list |> List.map (Filename.concat directory)
+
+let with_chdir dir f =
+  let old_cwd = getcwd () in
+  Unix.chdir dir;
+  let result = f () in
+  Unix.chdir old_cwd;
+  result
+
+let write_file file content =
+  let oc = open_out file in
+  Printf.fprintf oc "%s" content;
+  close_out oc
+
+let read_lines file : string list =
+  let ic = open_in file in
+  let try_read () = try Some (input_line ic) with End_of_file -> None in
+  let rec loop acc =
+    match try_read () with
+    | Some s ->
+      loop (s :: acc)
+    | None ->
+      close_in ic;
+      List.rev acc
+  in
+  loop []
+
+let read_file file = String.concat "\n" (read_lines file)

--- a/spin.opam
+++ b/spin.opam
@@ -17,15 +17,14 @@ depends: [
   "reason" {with-test}
   "odoc" {with-doc}
   "crunch" {build}
-  "base"
+  "sexplib0" {>= "v0.13"}
+  "inquire" {>= "0.3.0"}
+  "spawn" {>= "v0.13"}
   "fmt"
   "fpath"
   "cmdliner"
   "logs"
-  "sexplib"
-  "lwt" {>= "5.3.0"}
   "jingoo"
-  "inquire" {>= "0.2.1"}
 ]
 dev-repo: "git+https://github.com/tmattio/spin.git"
 build: [

--- a/template/cli/generators/cmd/main.ml
+++ b/template/cli/generators/cmd/main.ml
@@ -24,7 +24,7 @@ let man =
 let info = Term.info "{{ cmd_name }}" ~doc ~sdocs ~exits ~envs ~man
 
 let term =
-  let open Common.Let_syntax in
+  let open Common.Syntax in
   let+ _term = Common.term
   and+ name =
     let doc = "The name to greet." in

--- a/template/cli/template/bin/commands/cmd_hello.ml
+++ b/template/cli/template/bin/commands/cmd_hello.ml
@@ -25,7 +25,7 @@ let man =
 let info = Term.info "hello" ~doc ~sdocs ~exits ~envs ~man
 
 let term =
-  let open Common.Let_syntax in
+  let open Common.Syntax in
   let+ _term = Common.term
   and+ name =
     let doc = "The name to greet." in

--- a/template/cli/template/bin/common.ml
+++ b/template/cli/template/bin/common.ml
@@ -1,12 +1,12 @@
 open Cmdliner
 
-module Let_syntax = struct
+module Syntax = struct
   let ( let+ ) t f = Term.(const f $ t)
 
   let ( and+ ) a b = Term.(const (fun x y -> x, y) $ a $ b)
 end
 
-open Let_syntax
+open Syntax
 
 let envs =
   [ Term.env_info

--- a/template/cli/template/bin/common.mli
+++ b/template/cli/template/bin/common.mli
@@ -6,7 +6,7 @@ val envs : Cmdliner.Term.env_info list
 
 val exits : Cmdliner.Term.exit_info list
 
-module Let_syntax : sig
+module Syntax : sig
   val ( let+ ) : 'a Cmdliner.Term.t -> ('a -> 'b) -> 'b Cmdliner.Term.t
 
   val ( and+ )

--- a/template/cli/template/bin/main.ml
+++ b/template/cli/template/bin/main.ml
@@ -28,7 +28,7 @@ let man =
 
 let default_cmd =
   let term =
-    let open Common.Let_syntax in
+    let open Common.Syntax in
     Term.ret
     @@ let+ _ = Common.term in
        `Help (`Pager, None)

--- a/test/spin/decoder_test.ml
+++ b/test/spin/decoder_test.ml
@@ -4,33 +4,33 @@ open Test_utils
 
 let test_decode_field_of_string () =
   let f =
-    let open Decoder.Let_syntax in
-    let+ v = Decoder.field "field" ~f:Decoder.string in
+    let open Decoder.Syntax in
+    let+ v = Decoder.field "field" Decoder.string in
     v
   in
-  let decoded = Decoder.decode_string "((field value))" ~f in
+  let decoded = Decoder.decode_string "((field value))" f in
   check (decoder string) "same value" (Ok "value") decoded
 
 let test_decode_field_of_list () =
   let f =
-    let open Decoder.Let_syntax in
-    let+ v = Decoder.field "field" ~f:(Decoder.list Decoder.int) in
+    let open Decoder.Syntax in
+    let+ v = Decoder.field "field" (Decoder.list Decoder.int) in
     v
   in
-  let decoded = Decoder.decode_string "((field 1 2 3))" ~f in
+  let decoded = Decoder.decode_string "((field 1 2 3))" f in
   check (decoder (list int)) "same value" (Ok [ 1; 2; 3 ]) decoded;
-  let decoded = Decoder.decode_string "((field (1 2 3)))" ~f in
+  let decoded = Decoder.decode_string "((field (1 2 3)))" f in
   check (decoder (list int)) "same value" (Ok [ 1; 2; 3 ]) decoded
 
 let test_decode_field_opt () =
   let f =
-    let open Decoder.Let_syntax in
-    let+ v = Decoder.field_opt "field" ~f:Decoder.string in
+    let open Decoder.Syntax in
+    let+ v = Decoder.field_opt "field" Decoder.string in
     v
   in
-  let decoded = Decoder.decode_string "((field value))" ~f in
+  let decoded = Decoder.decode_string "((field value))" f in
   check (decoder (option string)) "same value" (Ok (Some "value")) decoded;
-  let decoded = Decoder.decode_string "()" ~f in
+  let decoded = Decoder.decode_string "()" f in
   check (decoder (option string)) "same value" (Ok None) decoded
 
 let suite =

--- a/test/spin/decoders/dec_common_test.ml
+++ b/test/spin/decoders/dec_common_test.ml
@@ -4,24 +4,24 @@ open Test_utils
 
 let test_decode_valid_name () =
   let f =
-    let open Decoder.Let_syntax in
-    let+ name = Decoder.field "name" ~f:Dec_common.Template_name.decode in
+    let open Decoder.Syntax in
+    let+ name = Decoder.field "name" Dec_common.Template_name.decode in
     name
   in
-  let decoded = Decoder.decode_string "((name valid))" ~f in
+  let decoded = Decoder.decode_string "((name valid))" f in
   check (decoder string) "same value" (Ok "valid") decoded;
-  let decoded = Decoder.decode_string "((name valid-with-dash))" ~f in
+  let decoded = Decoder.decode_string "((name valid-with-dash))" f in
   check (decoder string) "same value" (Ok "valid-with-dash") decoded;
-  let decoded = Decoder.decode_string "((name valid_with_underscore))" ~f in
+  let decoded = Decoder.decode_string "((name valid_with_underscore))" f in
   check (decoder string) "same value" (Ok "valid_with_underscore") decoded
 
 let test_decode_invalid_name () =
   let f =
-    let open Decoder.Let_syntax in
-    let+ name = Decoder.field "name" ~f:Dec_common.Template_name.decode in
+    let open Decoder.Syntax in
+    let+ name = Decoder.field "name" Dec_common.Template_name.decode in
     name
   in
-  let decoded = Decoder.decode_string {|((name "with space"))|} ~f in
+  let decoded = Decoder.decode_string {|((name "with space"))|} f in
   match decoded with Error _ -> () | Ok _ -> fail "name should not be decoded"
 
 let suite =

--- a/test/spin/decoders/dec_user_config_test.ml
+++ b/test/spin/decoders/dec_user_config_test.ml
@@ -12,7 +12,7 @@ let test_encode_config () =
       }
   in
   let f = Dec_user_config.encode in
-  let encoded = Encoder.encode_sexps_string t ~f in
+  let encoded = Encoder.encode_sexps_string t f in
   let expected =
     "(username Bill)\n\n\
      (email bill@email.com)\n\n\

--- a/test/spin/template_actions_test.ml
+++ b/test/spin/template_actions_test.ml
@@ -1,27 +1,23 @@
 open Alcotest
 open Spin
+open Spin_std
 
 let spin_error = Alcotest.of_pp Spin_error.pp
 
-let test_refmt () =
-  let temp_dir = Test_utils.get_tempdir "test_refmt" in
-  Spin_std.Spin_unix.mkdir_p temp_dir;
-  let temp_file = Caml.Filename.concat temp_dir "sample.ml" in
-  let oc = open_out temp_file in
-  Printf.fprintf oc "%s" {|let () = print_endline "Hello World"|};
-  close_out oc;
+let test_run_action () =
+  let temp_file = "sample.ml" in
   let result_ =
     Template_actions.run
       Template_actions.
-        { message = None; actions = [ Template_actions.Refmt [ "*.ml" ] ] }
+        { message = None
+        ; actions =
+            [ Template_actions.Run
+                Template_actions.{ name = "touch"; args = [ temp_file ] }
+            ]
+        }
       ~path:(Filename.dirname temp_file)
-    |> Lwt_main.run
   in
-  check (result unit spin_error) "" result_ (Ok ());
-  let output_file = Caml.Filename.chop_suffix temp_file ".ml" ^ ".re" in
-  let ic = open_in output_file in
-  let line = input_line ic in
-  close_in ic;
-  check string "equals" "let () = print_endline(\"Hello World\");" line
+  check (result unit spin_error) "" (Ok ()) result_;
+  check bool "file exists" true (Sys.file_exists temp_file)
 
-let suite = [ "can run a Refmt action", `Quick, test_refmt ]
+let suite = [ "can run an action", `Quick, test_run_action ]

--- a/test/spin_std/sys_test.ml
+++ b/test/spin_std/sys_test.ml
@@ -1,12 +1,12 @@
 open Alcotest
 
 let test_ls_dir () =
-  let temp_dir = Spin_std.Spin_sys.mk_temp_dir "spin-test" in
+  let temp_dir = Spin_std.Sys.mk_temp_dir "spin-test" in
   let temp_file = Filename.concat temp_dir "file" in
   let oc = open_out temp_file in
   Printf.fprintf oc "%s" "Hello world!";
   close_out oc;
-  let f_list = Spin_std.Spin_sys.ls_dir (Caml.Filename.dirname temp_file) in
+  let f_list = Spin_std.Sys.ls_dir (Filename.dirname temp_file) in
   check (list string) "equals" f_list [ temp_file ]
 
 let suite = [ "ls_dir returns the files in the directory", `Quick, test_ls_dir ]

--- a/test/support/test_runner.ml
+++ b/test/support/test_runner.ml
@@ -11,6 +11,6 @@ let () =
     [ "spin::Dec_common", Dec_common_test.suite
     ; "spin::Dec_user_config", Dec_user_config_test.suite
     ; "spin::Decoder", Decoder_test.suite
-    ; "spin_std::Spin_sys", Spin_sys_test.suite
+    ; "spin_std::Sys", Sys_test.suite
     ; "spin::Template_actions", Template_actions_test.suite
     ]

--- a/test/support/test_utils.ml
+++ b/test/support/test_utils.ml
@@ -17,5 +17,7 @@ let decoder a =
     eq
 
 let get_tempdir prefix =
-  Printf.sprintf "%s-%s" prefix (Unix.time () |> Float.to_int |> Int.to_string)
-  |> Caml.Filename.concat (Caml.Filename.get_temp_dir_name ())
+  let dirname =
+    Printf.sprintf "%s-%s" prefix (Unix.time () |> Float.to_int |> Int.to_string)
+  in
+  Spin_std.Sys.mk_temp_dir dirname

--- a/test_bin/dune
+++ b/test_bin/dune
@@ -1,3 +1,0 @@
-(cram
- (applies_to :whole_subtree)
- (deps %{bin:spin}))

--- a/test_bin/failure/dune
+++ b/test_bin/failure/dune
@@ -1,4 +1,4 @@
 (cram
  (applies_to :whole_subtree)
  (deps %{bin:spin})
- (enabled_if false))
+ (enabled_if true))

--- a/test_bin/failure/post-cmd-fail.t/run.t
+++ b/test_bin/failure/post-cmd-fail.t/run.t
@@ -4,6 +4,6 @@
   Done!
   
   spin: [ERROR] The template generation failed:
-  The command false did not run successfully: 
+  The command false did not run successfully: exited with code 1
   [7]
 

--- a/test_bin/success/dune
+++ b/test_bin/success/dune
@@ -1,4 +1,4 @@
 (cram
  (applies_to :whole_subtree)
  (deps %{bin:spin})
- (enabled_if false))
+ (enabled_if true))

--- a/test_bin/success/refmt-reason.t/run.t
+++ b/test_bin/success/refmt-reason.t/run.t
@@ -11,4 +11,4 @@
   file.ml
 
   $ cat _generated/file.ml
-  let () = print_endline "Hello World"
+  let () = print_endline (("Hello World")[@reason.raw_literal "Hello World"])


### PR DESCRIPTION
This PR removes the dependency on Lwt and Base and updates to `inquire.0.3.0` which now doesn't have any dependency.

The dependency on Lwt was unnecessary as there is absolutely no need for concurrency in Spin. Removing it makes the code much simpler and more readable.
As part of this, I refactored the way we run subcommands to use `spawn`. The `stdout` and `stderr` are now redirected to the parent process, so we don't can display some progress to the user.

I also removed the dependency on Base. updated to latest version of `inquire`, which has no dependency.
This is part of an effort to make Spin's dependency profile much leaner.
